### PR TITLE
Add unique notification ID generation for OID4VCI credential responses

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -204,6 +204,15 @@ public class OID4VCIssuerEndpoint {
     }
 
     /**
+     * Generates a unique notification ID for use in CredentialResponse.
+     *
+     * @return a unique string identifier
+     */
+    private String generateNotificationId() {
+        return SecretGenerator.getInstance().randomString();
+    }
+
+    /**
      * the OpenId4VCI nonce-endpoint
      *
      * @return a short-lived c_nonce value that must be presented in key-bound proofs at the credential endpoint.
@@ -408,7 +417,9 @@ public class OID4VCIssuerEndpoint {
 
         Object theCredential = getCredential(authResult, supportedCredentialConfiguration, credentialRequestVO);
         if (SUPPORTED_FORMATS.contains(requestedFormat)) {
-            responseVO.addCredential(theCredential);
+            responseVO
+                    .addCredential(theCredential)
+                    .setNotificationId(generateNotificationId());
         } else {
             throw new BadRequestException(getErrorResponse(ErrorType.UNSUPPORTED_CREDENTIAL_TYPE));
         }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialResponse.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialResponse.java
@@ -50,11 +50,12 @@ public class CredentialResponse {
         return this;
     }
 
-    public void addCredential(Object credential) {
+    public CredentialResponse addCredential(Object credential) {
         if (this.credentials == null) {
             this.credentials = new ArrayList<>();
         }
         this.credentials.add(new Credential().setCredential(credential));
+        return this;
     }
 
     public String getTransactionId() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -64,6 +64,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -538,5 +539,34 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                         throw new RuntimeException(e);
                     }
                 });
+    }
+
+    @Test
+    public void testRequestCredentialWithNotificationId() {
+        String token = getBearerToken(oauth);
+        testingClient.server(TEST_REALM_NAME).run((session) -> {
+            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            authenticator.setTokenString(token);
+            OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
+
+            CredentialRequest credentialRequest = new CredentialRequest()
+                    .setFormat(Format.JWT_VC)
+                    .setCredentialIdentifier("test-credential");
+
+            // First credential request
+            Response response1 = issuerEndpoint.requestCredential(credentialRequest);
+            assertEquals("The credential request should be successful.", 200, response1.getStatus());
+            CredentialResponse credentialResponse1 = JsonSerialization.mapper.convertValue(response1.getEntity(), CredentialResponse.class);
+            assertNotNull("Credential response should not be null", credentialResponse1);
+            assertNotNull("Credential should be present", credentialResponse1.getCredentials());
+            assertNotNull("Notification ID should be present", credentialResponse1.getNotificationId());
+            assertFalse("Notification ID should not be empty", credentialResponse1.getNotificationId().isEmpty());
+
+            // Second credential request
+            Response response2 = issuerEndpoint.requestCredential(credentialRequest);
+            assertEquals("The second credential request should be successful.", 200, response2.getStatus());
+            CredentialResponse credentialResponse2 = JsonSerialization.mapper.convertValue(response2.getEntity(), CredentialResponse.class);
+            assertNotEquals("Notification IDs should be unique", credentialResponse1.getNotificationId(), credentialResponse2.getNotificationId());
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Enhanced OID4VCI issuer endpoint with unique notification ID generation
- Improved credential response handling with proper notification tracking
- Added unique identifier support for credential issuance notifications

## Changes
- Implemented unique notification_id generation in OID4VCIssuerEndpoint
- Enhanced CredentialResponse with notification tracking capabilities
- Updated credential issuance flow to include proper notification handling

## Test plan
- [ ] Test OID4VCI credential issuance with notification IDs
- [ ] Verify unique notification ID generation
- [ ] Confirm credential response includes proper notification data
- [ ] Test notification tracking functionality

🤖 Generated with [Claude Code](https://claude.ai/code)