### PR TITLE
Implement recovery key support for user storage providers

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/utils/RecoveryAuthnCodesUtils.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/RecoveryAuthnCodesUtils.java
@@ -1,11 +1,15 @@
 package org.keycloak.models.utils;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.credential.CredentialModel;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.JavaAlgorithm;
 import org.keycloak.jose.jws.crypto.HashUtils;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.credential.RecoveryAuthnCodesCredentialModel;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -43,4 +47,17 @@ public class RecoveryAuthnCodesUtils {
         return Stream.generate(code).limit(QUANTITY_OF_CODES_TO_GENERATE).collect(Collectors.toList());
     }
 
+    /**
+     * Checks the user storage for the credential. If not found it will look for the credential in the local storage
+     *
+     * @param user - User model
+     * @return - a optional  credential model
+     */
+    public static Optional<CredentialModel> getCredential(UserModel user) {
+        return user.credentialManager()
+                .getFederatedCredentialsStream()
+                .filter(c -> RecoveryAuthnCodesCredentialModel.TYPE.equals(c.getType()))
+                .findFirst()
+                .or(() -> user.credentialManager().getStoredCredentialsByTypeStream(RecoveryAuthnCodesCredentialModel.TYPE).findFirst());
+    }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
@@ -77,8 +77,7 @@ public class RecoveryAuthnCodesFormAuthenticator implements Authenticator {
                 authnFlowContext.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, responseChallenge);
             } else {
                 result = true;
-                Optional<CredentialModel> optUserCredentialFound = authenticatedUser.credentialManager().getStoredCredentialsByTypeStream(
-                        RecoveryAuthnCodesCredentialModel.TYPE).findFirst();
+                Optional<CredentialModel> optUserCredentialFound = RecoveryAuthnCodesUtils.getCredential(authenticatedUser);
                 RecoveryAuthnCodesCredentialModel recoveryCodeCredentialModel = null;
                 if (optUserCredentialFound.isPresent()) {
                     recoveryCodeCredentialModel = RecoveryAuthnCodesCredentialModel

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/RecoveryAuthnCodesAction.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/RecoveryAuthnCodesAction.java
@@ -2,6 +2,7 @@ package org.keycloak.authentication.requiredactions;
 
 import java.util.Arrays;
 import java.util.List;
+
 import org.keycloak.Config;
 import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.authentication.CredentialRegistrator;
@@ -11,8 +12,6 @@ import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticator;
 import org.keycloak.common.Profile;
-import org.keycloak.credential.RecoveryAuthnCodesCredentialProviderFactory;
-import org.keycloak.credential.CredentialProvider;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
@@ -25,6 +24,8 @@ import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.keycloak.sessions.AuthenticationSessionModel;
+
+import static org.keycloak.utils.CredentialHelper.createRecoveryCodesCredential;
 
 public class RecoveryAuthnCodesAction implements RequiredActionProvider, RequiredActionFactory, EnvironmentDependentProviderFactory, CredentialRegistrator {
 
@@ -86,12 +87,7 @@ public class RecoveryAuthnCodesAction implements RequiredActionProvider, Require
     public void processAction(RequiredActionContext reqActionContext) {
         EventBuilder event = reqActionContext.getEvent();
         event.event(EventType.UPDATE_CREDENTIAL);
-
-        CredentialProvider recoveryCodeCredentialProvider;
         MultivaluedMap<String, String> httpReqParamsMap;
-
-        recoveryCodeCredentialProvider = reqActionContext.getSession().getProvider(CredentialProvider.class,
-                RecoveryAuthnCodesCredentialProviderFactory.PROVIDER_ID);
 
         event.detail(Details.CREDENTIAL_TYPE, RecoveryAuthnCodesCredentialModel.TYPE);
 
@@ -117,8 +113,7 @@ public class RecoveryAuthnCodesAction implements RequiredActionProvider, Require
             AuthenticatorUtil.logoutOtherSessions(reqActionContext);
         }
 
-        recoveryCodeCredentialProvider.createCredential(reqActionContext.getRealm(), reqActionContext.getUser(),
-                credentialModel);
+        createRecoveryCodesCredential(reqActionContext.getSession(), reqActionContext.getRealm(), reqActionContext.getUser(), credentialModel, generatedCodes);
 
         reqActionContext.success();
     }

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/RecoveryAuthnCodeInputLoginBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/RecoveryAuthnCodeInputLoginBean.java
@@ -5,16 +5,18 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.RecoveryAuthnCodesCredentialModel;
+import org.keycloak.models.utils.RecoveryAuthnCodesUtils;
+
+import java.util.Optional;
 
 public class RecoveryAuthnCodeInputLoginBean {
 
     private final int codeNumber;
 
     public RecoveryAuthnCodeInputLoginBean(KeycloakSession session, RealmModel realm, UserModel user) {
-        CredentialModel credentialModel = user.credentialManager().getStoredCredentialsByTypeStream(RecoveryAuthnCodesCredentialModel.TYPE)
-                                                 .findFirst().get();
+        Optional<CredentialModel> credentialModelOpt = RecoveryAuthnCodesUtils.getCredential(user);
 
-        RecoveryAuthnCodesCredentialModel recoveryCodeCredentialModel = RecoveryAuthnCodesCredentialModel.createFromCredentialModel(credentialModel);
+        RecoveryAuthnCodesCredentialModel recoveryCodeCredentialModel = RecoveryAuthnCodesCredentialModel.createFromCredentialModel(credentialModelOpt.get());
 
         this.codeNumber = recoveryCodeCredentialModel.getNextRecoveryAuthnCode().get().getNumber();
     }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorage.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorage.java
@@ -18,11 +18,12 @@
 
 package org.keycloak.testsuite.federation;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jboss.logging.Logger;
@@ -33,7 +34,6 @@ import org.keycloak.credential.CredentialInputUpdater;
 import org.keycloak.credential.CredentialInputValidator;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.hash.PasswordHashProvider;
-import org.keycloak.credential.hash.Pbkdf2Sha512PasswordHashProviderFactory;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OTPPolicy;
@@ -43,6 +43,8 @@ import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.credential.PasswordUserCredentialModel;
+import org.keycloak.models.credential.RecoveryAuthnCodesCredentialModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.TimeBasedOTP;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
@@ -51,11 +53,12 @@ import org.keycloak.storage.adapter.AbstractUserAdapterFederatedStorage;
 import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserQueryProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
+import org.keycloak.util.JsonSerialization;
 
 /**
  * UserStorage implementation created in Keycloak 4.8.3. It is used for backwards compatibility testing. Future Keycloak versions
  * should work fine without a need to change the code of this provider.
- *
+ * <p>
  * TODO: Have some good mechanims to make sure that source code of this provider is really compatible with Keycloak 4.8.3
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -89,7 +92,7 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     private UserModel createUser(RealmModel realm, String username) {
-        return new AbstractUserAdapterFederatedStorage(session, realm,  model) {
+        return new AbstractUserAdapterFederatedStorage(session, realm, model) {
             @Override
             public String getUsername() {
                 return username;
@@ -107,7 +110,8 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     @Override
     public boolean supportsCredentialType(String credentialType) {
         if (CredentialModel.PASSWORD.equals(credentialType)
-                || isOTPType(credentialType)) {
+                || isOTPType(credentialType)
+                || credentialType.equals(RecoveryAuthnCodesCredentialModel.TYPE)) {
             return true;
         } else {
             log.infof("Unsupported credential type: %s", credentialType);
@@ -172,6 +176,7 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
             OTPPolicy otpPolicy = session.getContext().getRealm().getOTPPolicy();
 
             CredentialModel newOTP = new CredentialModel();
+            newOTP.setId(KeycloakModelUtils.generateId());
             newOTP.setType(input.getType());
             long createdDate = Time.currentTimeMillis();
             newOTP.setCreatedDate(createdDate);
@@ -184,6 +189,15 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
 
             users.get(translateUserName(user.getUsername())).otp = newOTP;
 
+            return true;
+        } else if (input.getType().equals(RecoveryAuthnCodesCredentialModel.TYPE)) {
+            CredentialModel recoveryCodesModel = new CredentialModel();
+            recoveryCodesModel.setId(KeycloakModelUtils.generateId());
+            recoveryCodesModel.setType(input.getType());
+            recoveryCodesModel.setCredentialData(input.getChallengeResponse());
+            long createdDate = Time.currentTimeMillis();
+            recoveryCodesModel.setCreatedDate(createdDate);
+            users.get(translateUserName(user.getUsername())).recoveryCodes = recoveryCodesModel;
             return true;
         } else {
             log.infof("Attempt to update unsupported credential of type: %s", input.getType());
@@ -214,6 +228,30 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
     }
 
     @Override
+    public Stream<CredentialModel> getCredentials(RealmModel realm, UserModel user) {
+        var myUser = getMyUser(user);
+        RecoveryAuthnCodesCredentialModel model;
+        List<CredentialModel> credentialModels = new ArrayList<>();
+        if (myUser.recoveryCodes != null) {
+            try {
+                model = RecoveryAuthnCodesCredentialModel.createFromValues(
+                        JsonSerialization.readValue(myUser.recoveryCodes.getCredentialData(), List.class),
+                        myUser.recoveryCodes.getCreatedDate(),
+                        myUser.recoveryCodes.getUserLabel()
+                );
+                credentialModels.add(model);
+            } catch (IOException e) {
+                log.error("Could not deserialize  credential of type: recovery-codes");
+            }
+        }
+        if (myUser.otp != null) {
+            credentialModels.add(myUser.getOtp());
+        }
+
+        return credentialModels.stream();
+    }
+
+    @Override
     public Stream<String> getDisableableCredentialTypesStream(RealmModel realm, UserModel user) {
         Set<String> types = new HashSet<>();
 
@@ -233,6 +271,8 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
         if (myUser == null) return false;
 
         if (isOTPType(credentialType) && myUser.otp != null) {
+            return true;
+        } else if (credentialType.equals(RecoveryAuthnCodesCredentialModel.TYPE) && myUser.recoveryCodes != null) {
             return true;
         } else {
             log.infof("Not supported credentialType '%s' for user '%s'", credentialType, user.getUsername());
@@ -283,7 +323,22 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
             TimeBasedOTP validator = new TimeBasedOTP(storedOTPCredential.getAlgorithm(), storedOTPCredential.getDigits(),
                     storedOTPCredential.getPeriod(), realm.getOTPPolicy().getLookAheadWindow());
             return validator.validateTOTP(otpCredential.getValue(), storedOTPCredential.getValue().getBytes());
-        } else {
+        } else if (input.getType().equals(RecoveryAuthnCodesCredentialModel.TYPE)) {
+            CredentialModel storedRecoveryKeys = myUser.recoveryCodes;
+            if (storedRecoveryKeys == null) {
+                log.warnf("Not found credential for the user %s", user.getUsername());
+                return false;
+            }
+            List generatedKeys;
+            try {
+                generatedKeys = JsonSerialization.readValue(storedRecoveryKeys.getCredentialData(), List.class);
+            } catch (IOException e) {
+                log.warnf("Cannot deserialize recovery keys credential for the user %s", user.getUsername());
+                return false;
+            }
+
+            return generatedKeys.stream().anyMatch(key -> key.equals(input.getChallengeResponse()));
+        }  else {
             log.infof("Not supported to validate credential of type '%s' for user '%s'", input.getType(), user.getUsername());
             return false;
         }
@@ -369,6 +424,7 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
         private String username;
         private CredentialModel hashedPassword;
         private CredentialModel otp;
+        private CredentialModel recoveryCodes;
 
         private MyUser(String username) {
             this.username = username;
@@ -376,6 +432,10 @@ public class BackwardsCompatibilityUserStorage implements UserLookupProvider, Us
 
         public CredentialModel getOtp() {
             return otp;
+        }
+
+        public CredentialModel getRecoveryCodes() {
+            return recoveryCodes;
         }
     }
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorageFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/BackwardsCompatibilityUserStorageFactory.java
@@ -50,4 +50,9 @@ public class BackwardsCompatibilityUserStorageFactory implements UserStorageProv
         return user.getOtp() != null;
     }
 
+    public boolean hasRecoveryCodes(String username) {
+        BackwardsCompatibilityUserStorage.MyUser user = userPasswords.get(username);
+        if (user == null) return false;
+        return user.getRecoveryCodes() != null;
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/BackwardsCompatibilityUserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/BackwardsCompatibilityUserStorageTest.java
@@ -24,7 +24,11 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.authentication.AuthenticationFlow;
+import org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticatorFactory;
+import org.keycloak.authentication.authenticators.browser.UsernamePasswordFormFactory;
 import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.OTPCredentialModel;
@@ -41,24 +45,33 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.broker.util.SimpleHttpDefault;
+import org.keycloak.testsuite.client.KeycloakTestingClient;
 import org.keycloak.testsuite.federation.BackwardsCompatibilityUserStorageFactory;
+import org.keycloak.testsuite.forms.BrowserFlowTest;
 import org.keycloak.testsuite.pages.AppPage;
+import org.keycloak.testsuite.pages.EnterRecoveryAuthnCodePage;
 import org.keycloak.testsuite.pages.LoginConfigTotpPage;
 import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.pages.LoginTotpPage;
+import org.keycloak.testsuite.pages.SetupRecoveryAuthnCodesPage;
+import org.keycloak.testsuite.util.FlowUtil;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.TestAppHelper;
 
 import jakarta.ws.rs.core.Response;
 import org.keycloak.testsuite.util.TokenUtil;
+import org.openqa.selenium.WebDriver;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import static org.keycloak.common.Profile.Feature.RECOVERY_CODES;
 import static org.wildfly.common.Assert.assertTrue;
 
 /**
@@ -66,7 +79,10 @@ import static org.wildfly.common.Assert.assertTrue;
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
+@EnableFeature(value = RECOVERY_CODES, skipRestart = true)
 public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeycloakTest {
+
+    private static final String BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES = "Browser with Recovery Authentication Codes";
 
     private String backwardsCompProviderId;
 
@@ -82,6 +98,12 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
     @Page
     protected LoginConfigTotpPage configureTotpRequiredActionPage;
 
+    @Page
+    protected SetupRecoveryAuthnCodesPage setupRecoveryAuthnCodesPage;
+
+    @Page
+    protected EnterRecoveryAuthnCodePage enterRecoveryAuthnCodePage;
+
 
     private TimeBasedOTP totp = new TimeBasedOTP();
 
@@ -96,6 +118,28 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
 
         backwardsCompProviderId = addComponent(memProvider);
 
+    }
+
+    void configureBrowserFlowWithRecoveryAuthnCodes(KeycloakTestingClient testingClient, long delay) {
+        final String newFlowAlias = BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES;
+        testingClient.server("test").run(session -> FlowUtil.inCurrentRealm(session).copyBrowserFlow(newFlowAlias));
+        testingClient.server("test").run(session -> FlowUtil.inCurrentRealm(session)
+                .selectFlow(newFlowAlias)
+                .inForms(forms -> forms
+                        .clear()
+                        .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.REQUIRED, UsernamePasswordFormFactory.PROVIDER_ID)
+                        .addSubFlowExecution(AuthenticationExecutionModel.Requirement.REQUIRED, reqSubFlow -> reqSubFlow
+                                .addSubFlowExecution("Recovery-Authn-Codes subflow", AuthenticationFlow.BASIC_FLOW, AuthenticationExecutionModel.Requirement.ALTERNATIVE, altSubFlow -> altSubFlow
+                                        .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.REQUIRED, RecoveryAuthnCodesFormAuthenticatorFactory.PROVIDER_ID)
+                                        .addAuthenticatorExecution(AuthenticationExecutionModel.Requirement.REQUIRED, "delayed-authenticator", config -> {
+                                            config.setAlias("delayed-suthenticator-config");
+                                            config.setConfig(Map.of("delay", Long.toString(delay)));
+                                        })
+                                )
+                        )
+                )
+                .defineAsBrowserFlow()
+        );
     }
 
     protected String addComponent(ComponentRepresentation component) {
@@ -194,6 +238,37 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
     }
 
     @Test
+    public void testRecoveryKeysSetupAndLogin() throws URISyntaxException, IOException {
+        try {
+            configureBrowserFlowWithRecoveryAuthnCodes(testingClient, 0);
+
+            String userId = addUserAndResetPassword("otp1", "pass");
+            getCleanup().addUserId(userId);
+
+            // Setup RecoveryKeys
+            List<String> recoveryKeys = setupRecoveryKeysForUserWithRequiredAction(userId, true);
+
+            // Assert user has RecoveryKeys in the userStorage
+            assertUserDontHaveDBCredentials();
+            assertUserHasRecoveryKeysCredentialInUserStorage(true);
+
+            TestAppHelper testAppHelper = new TestAppHelper(oauth, loginPage, appPage);
+
+            // Authenticate as the user
+            testAppHelper.startLogin("otp1", "pass");
+            enterRecoveryCodes(enterRecoveryAuthnCodePage, driver, 0, recoveryKeys);
+            enterRecoveryAuthnCodePage.clickSignInButton();
+
+            appPage.assertCurrent();
+
+            testAppHelper.logout();
+        } finally {
+            // Revert copy of browser flow to original to keep clean slate after this test
+            BrowserFlowTest.revertFlows(testRealm(), BROWSER_FLOW_WITH_RECOVERY_AUTHN_CODES);
+        }
+    }
+
+    @Test
     public void testOTPSetupThroughAdminRESTAndLogin() throws URISyntaxException, IOException {
         String userId = addUserAndResetPassword("otp1", "pass");
         getCleanup().addUserId(userId);
@@ -250,7 +325,7 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
 
         // Delete OTP credential from federated storage
         int deleteStatus = SimpleHttpDefault.doDelete(accountCredentialsUrl + "/" + otpCredentialId, oauth.httpClient().get())
-            .auth(accountToken).acceptJson().asStatus();
+                .auth(accountToken).acceptJson().asStatus();
         Assert.assertEquals(204, deleteStatus);
 
         // Get credentials by account REST. User should not have OTP credential
@@ -332,6 +407,34 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         return totpSecret;
     }
 
+    private List<String> setupRecoveryKeysForUserWithRequiredAction(String userId, boolean logoutOtherSessions) throws URISyntaxException, IOException {
+        // Add required action to the user to reset RecoveryKeys
+        UserResource user = testRealm().users().get(userId);
+        UserRepresentation userRep = user.toRepresentation();
+        userRep.setRequiredActions(Arrays.asList(UserModel.RequiredAction.CONFIGURE_RECOVERY_AUTHN_CODES.name()));
+        user.update(userRep);
+
+        TestAppHelper testAppHelper = new TestAppHelper(oauth, loginPage, appPage);
+
+        // Login as the user and setup RecoveryKeys
+        testAppHelper.startLogin("otp1", "pass");
+
+        setupRecoveryAuthnCodesPage.assertCurrent();
+        if (!logoutOtherSessions) {
+            setupRecoveryAuthnCodesPage.uncheckLogoutSessions();
+        }
+        List<String> codes = setupRecoveryAuthnCodesPage.getRecoveryAuthnCodes();
+        setupRecoveryAuthnCodesPage.clickSaveRecoveryAuthnCodesButton();
+        appPage.assertCurrent();
+
+        testAppHelper.completeLogin();
+
+        // Logout
+        assertTrue(testAppHelper.logout());
+
+        return codes;
+    }
+
 
     private void assertUserDontHaveDBCredentials() {
         testingClient.server().run(session -> {
@@ -350,14 +453,33 @@ public class BackwardsCompatibilityUserStorageTest extends AbstractTestRealmKeyc
         Assert.assertEquals(expectedUserHasOTP, hasUserOTP);
     }
 
+    private void assertUserHasRecoveryKeysCredentialInUserStorage(boolean expectedUserHasRecoveryKeys) {
+        boolean hasRecoveryKeys = testingClient.server().fetch(session -> {
+            BackwardsCompatibilityUserStorageFactory storageFactory = (BackwardsCompatibilityUserStorageFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(UserStorageProvider.class, BackwardsCompatibilityUserStorageFactory.PROVIDER_ID);
+            return storageFactory.hasRecoveryCodes("otp1");
+        }, Boolean.class);
+        Assert.assertEquals(expectedUserHasRecoveryKeys, hasRecoveryKeys);
+    }
+
     private List<CredentialMetadataRepresentation> getOtpCredentialFromAccountREST(String accountCredentialsUrl, CloseableHttpClient httpClient, TokenUtil tokenUtil) throws IOException {
         List<AccountCredentialResource.CredentialContainer> credentials = SimpleHttpDefault.doGet(accountCredentialsUrl, httpClient)
-                .auth(tokenUtil.getToken()).asJson(new TypeReference<>() {});
+                .auth(tokenUtil.getToken()).asJson(new TypeReference<>() {
+                });
 
         return credentials.stream()
                 .filter(credentialContainer -> OTPCredentialModel.TYPE.equals(credentialContainer.getType()))
                 .map(AccountCredentialResource.CredentialContainer::getUserCredentialMetadatas)
                 .findFirst().get();
+    }
+
+    private void enterRecoveryCodes(EnterRecoveryAuthnCodePage enterRecoveryAuthnCodePage, WebDriver driver,
+                                    int expectedCode, List<String> generatedRecoveryAuthnCodes) {
+        enterRecoveryAuthnCodePage.setDriver(driver);
+        enterRecoveryAuthnCodePage.assertCurrent();
+        int requestedCode = enterRecoveryAuthnCodePage.getRecoveryAuthnCodeToEnterNumber();
+        org.junit.Assert.assertEquals("Incorrect code presented to login", expectedCode, requestedCode);
+        enterRecoveryAuthnCodePage.enterRecoveryAuthnCode(generatedRecoveryAuthnCodes.get(requestedCode));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Added support for creating recovery keys in both user storage and local storage
- Enhanced CredentialHelper with flexible recovery key generation
- Implemented backward compatibility for user storage providers
- Extended recovery authentication flow with storage-aware functionality

## Changes
- Modified CredentialHelper to support multiple storage backends for recovery keys
- Added RecoveryAuthnCodesUtils for centralized recovery key management
- Updated RecoveryAuthnCodesFormAuthenticator with enhanced storage handling
- Enhanced BackwardsCompatibilityUserStorage with recovery key capabilities
- Added comprehensive test coverage for recovery key storage scenarios

## Test plan
- [ ] Test recovery key creation in local storage
- [ ] Test recovery key creation in user storage providers
- [ ] Verify backward compatibility with existing user storage implementations
- [ ] Test recovery authentication flow with different storage backends
- [ ] Confirm recovery key validation works across storage types

🤖 Generated with [Claude Code](https://claude.ai/code)