### PR TITLE
Support custom parameter builder for login URL construction

### DIFF
--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
@@ -47,12 +47,12 @@ public abstract class AbstractOAuthClient<T> {
         return (T) this;
     }
 
-    public String getLoginFormUrl() {
-        return new LoginUrlBuilder(this).toString();
+    public LoginUrlBuilder loginForm() {
+        return new LoginUrlBuilder(this);
     }
 
     public void openLoginForm() {
-        driver.navigate().to(getLoginFormUrl());
+        loginForm().open();
     }
 
     public AuthorizationEndpointResponse doLogin(String username, String password) {
@@ -62,6 +62,14 @@ public abstract class AbstractOAuthClient<T> {
     }
 
     public abstract void fillLoginForm(String username, String password);
+
+    public void openRegistrationForm() {
+        driver.navigate().to(registrationForm().build());
+    }
+
+    public RegistrationUrlBuilder registrationForm() {
+        return new RegistrationUrlBuilder(this);
+    }
 
     public AuthorizationEndpointResponse parseLoginResponse() {
         return new AuthorizationEndpointResponse(this);

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractUrlBuilder.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractUrlBuilder.java
@@ -16,7 +16,7 @@ public abstract class AbstractUrlBuilder {
     protected abstract void initRequest();
 
     public void open() {
-        client.driver.navigate().to(toString());
+        client.driver.navigate().to(build());
     }
 
     protected void parameter(String name, String value) {
@@ -25,9 +25,16 @@ public abstract class AbstractUrlBuilder {
         }
     }
 
-    public String toString() {
+    protected void replaceParameter(String name, String value) {
+        if (value != null) {
+            uriBuilder.replaceQueryParam(name, value);
+        }
+    }
+
+    public String build() {
         uriBuilder = UriBuilder.fromUri(getEndpoint());
         initRequest();
+
         return uriBuilder.build().toString();
     }
 

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/LoginUrlBuilder.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/LoginUrlBuilder.java
@@ -4,7 +4,12 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class LoginUrlBuilder extends AbstractUrlBuilder {
+
+    private Map<String, String> customParameters;
 
     public LoginUrlBuilder(AbstractOAuthClient<?> client) {
         super(client);
@@ -13,6 +18,24 @@ public class LoginUrlBuilder extends AbstractUrlBuilder {
     @Override
     public String getEndpoint() {
         return client.getEndpoints().getAuthorization();
+    }
+
+    public LoginUrlBuilder param(String name, String value) {
+        if (customParameters == null) {
+            customParameters = new HashMap<>();
+        }
+        customParameters.put(name, value);
+        return this;
+    }
+
+    public LoginUrlBuilder prompt(String value) {
+        param(OIDCLoginProtocol.PROMPT_PARAM, value);
+        return this;
+    }
+
+    public LoginUrlBuilder loginHint(String value) {
+        param(OIDCLoginProtocol.LOGIN_HINT_PARAM, value);
+        return this;
     }
 
     @Override
@@ -42,6 +65,10 @@ public class LoginUrlBuilder extends AbstractUrlBuilder {
 
         if (client.getCustomParameters() != null) {
             client.getCustomParameters().forEach(this::parameter);
+        }
+
+        if (customParameters != null) {
+            customParameters.forEach(this::replaceParameter);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/oauth/OAuthClient.java
@@ -162,14 +162,6 @@ public class OAuthClient extends AbstractOAuthClient<OAuthClient> {
         this.driver = driver;
     }
 
-    public void openRegistrationForm() {
-        driver.navigate().to(getRegistrationFormUrl());
-    }
-
-    public String getRegistrationFormUrl() {
-        return new RegistrationUrlBuilder(this).toString();
-    }
-
     public AuthorizationEndpointResponse doSilentLogin() {
         openLoginForm();
         WaitUtils.waitForPageToLoad();
@@ -187,25 +179,9 @@ public class OAuthClient extends AbstractOAuthClient<OAuthClient> {
         return parseLoginResponse();
     }
 
-    public AuthorizationEndpointResponse doRememberMeLogin(String username, String password) {
-        openLoginForm();
-        fillLoginForm(username, password, true);
-
-        return parseLoginResponse();
-    }
-
     public void fillLoginForm(String username, String password) {
-        this.fillLoginForm(username, password, false);
-    }
-
-    public void fillLoginForm(String username, String password, boolean rememberMe) {
         LoginPage loginPage = new LoginPage();
         PageFactory.initElements(driver, loginPage);
-
-        if (rememberMe) {
-            loginPage.setRememberMe(true);
-        }
-
         loginPage.login(username, password);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowCookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowCookieTest.java
@@ -32,7 +32,7 @@ public class CustomAuthFlowCookieTest extends AbstractCustomAccountManagementTes
     public void cookieAlternative() {
         //test default setting of cookie provider
         //login
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         
         //check SSO is working
@@ -47,7 +47,7 @@ public class CustomAuthFlowCookieTest extends AbstractCustomAccountManagementTes
         updateRequirement("browser", "auth-cookie", Requirement.DISABLED);
         
         //login
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         
         //SSO shouldn't work

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowOTPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/custom/CustomAuthFlowOTPTest.java
@@ -105,7 +105,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
 
     private void configureOTP() {
         //configure OTP for test user
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         String totpSecret = testRealmLoginPage.form().totpForm().getTotpSecret();
         testRealmLoginPage.form().totpForm().setTotp(totp.generateTOTP(totpSecret));
@@ -126,12 +126,12 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         testRealmResource().update(realm);
 
         updateRequirement("browser", Requirement.REQUIRED, (authExec) -> authExec.getDisplayName().equals("Browser - Conditional OTP"));
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertTrue(loginConfigTotpPage.isCurrent());
 
         configureOTP();
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup
@@ -160,12 +160,12 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
             testRealmResource().update(realm);
 
             updateRequirement("browser", Requirement.REQUIRED, (authExec) -> authExec.getDisplayName().equals("Browser - Conditional OTP"));
-            driver.navigate().to(oauth.getLoginFormUrl());
+            oauth.openLoginForm();
             testRealmLoginPage.form().login(testUser);
             assertTrue(loginConfigTotpPage.isCurrent());
 
             //configure OTP for test user
-            driver.navigate().to(oauth.getLoginFormUrl());
+            oauth.openLoginForm();
             testRealmLoginPage.form().login(testUser);
 
             final String totpSecret = testRealmLoginPage.form().totpForm().getTotpSecret();
@@ -178,7 +178,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
             testRealmLoginPage.form().totpForm().submit();
             AccountHelper.logout(testRealmResource(), testUser.getUsername());
 
-            driver.navigate().to(oauth.getLoginFormUrl());
+            oauth.openLoginForm();
             testRealmLoginPage.form().login(testUser);
 
             loginTotpPage.assertCurrent();
@@ -200,7 +200,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(config);
 
         //test OTP is required
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup
@@ -216,7 +216,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(config);
 
         //test OTP is skipped
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertCurrentUrlStartsWith(oauth.APP_AUTH_ROOT);
     }
@@ -231,12 +231,12 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(config);
         
         //test OTP is forced
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertTrue(loginConfigTotpPage.isCurrent());
 
         configureOTP();
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup
@@ -258,7 +258,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(config);
 
         //test OTP is required
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup
@@ -279,7 +279,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(config);
 
         //test OTP is skipped
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertCurrentUrlStartsWith(oauth.APP_AUTH_ROOT);
     }
@@ -298,12 +298,12 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(config);
         
         //test OTP is forced
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertTrue(loginConfigTotpPage.isCurrent());
 
         configureOTP();
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup
@@ -324,7 +324,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         testRealmResource().users().get(testUser.getId()).update(testUser);
 
         //test OTP is skipped
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         assertCurrentUrlStartsWith(oauth.APP_AUTH_ROOT);
@@ -344,12 +344,12 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         testRealmResource().users().get(testUser.getId()).update(testUser);
 
         //test OTP is required
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertTrue(loginConfigTotpPage.isCurrent());
 
         configureOTP();
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup
@@ -374,7 +374,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         testRealmResource().users().get(testUser.getId()).roles().realmLevel().add(realmRoles);
 
         //test OTP is skipped
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertCurrentUrlStartsWith(oauth.APP_AUTH_ROOT);
     }
@@ -397,13 +397,13 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         testRealmResource().users().get(testUser.getId()).roles().realmLevel().add(realmRoles);
 
         //test OTP is required
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         assertTrue(loginConfigTotpPage.isCurrent());
 
         configureOTP();
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup
@@ -426,13 +426,13 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         testRealmResource().users().get(testUser.getId()).joinGroup(group.getId());
 
         //test OTP is required
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         assertTrue(loginConfigTotpPage.isCurrent());
 
         configureOTP();
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup
@@ -445,13 +445,13 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(null);
 
         // test OTP is required
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         assertTrue(loginConfigTotpPage.isCurrent());
 
         configureOTP();
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         // verify that the page is login page, not totp setup
@@ -492,7 +492,7 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(config);
 
         //test OTP is skipped
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertCurrentUrlStartsWith(oauth.APP_AUTH_ROOT);
     }
@@ -508,12 +508,12 @@ public class CustomAuthFlowOTPTest extends AbstractCustomAccountManagementTest {
         setConditionalOTPForm(config);
 
         //test OTP is required
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
         assertEquals(PageUtils.getPageTitle(driver), "Mobile Authenticator Setup");
 
         configureOTP();
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(testUser);
 
         //verify that the page is login page, not totp setup

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedRegistrationTest.java
@@ -1,6 +1,5 @@
 package org.keycloak.testsuite.actions;
 
-import jakarta.ws.rs.core.UriBuilder;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,11 +32,9 @@ public class AppInitiatedRegistrationTest extends AbstractTestRealmKeycloakTest 
     @Test
     public void ensureLocaleParameterIsPropagatedDuringAppInitiatedRegistration() {
 
-        var appInitiatedRegisterUrlBuilder = UriBuilder.fromUri(oauth.getRegistrationFormUrl());
-        appInitiatedRegisterUrlBuilder.queryParam(LocaleSelectorProvider.KC_LOCALE_PARAM, "en");
-        var appInitiatedRegisterUrl = appInitiatedRegisterUrlBuilder.build().toString();
-
-        driver.navigate().to(appInitiatedRegisterUrl);
+        oauth.registrationForm()
+                .param(LocaleSelectorProvider.KC_LOCALE_PARAM, "en")
+                .open();
 
         registerPage.assertCurrent();
         registerPage.register("first", "last", "test-user@localhost", "test-user", "test","test");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -889,7 +889,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
             appPage.assertCurrent();
 
             // Browser 2: Log in
-            driver2.navigate().to(oauth.getLoginFormUrl());
+            driver2.navigate().to(oauth.loginForm().build());
 
             assertThat(driver2.getTitle(), is("Sign in to " + testRealmName));
             driver2.findElement(By.id("username")).sendKeys("test-user@localhost");
@@ -1044,7 +1044,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         assertThat(driver2.getPageSource(), Matchers.containsString("kc-info-message"));
         assertThat(driver2.getPageSource(), Matchers.containsString("Your email address has been verified."));
 
-        driver2.navigate().to(oauth.getLoginFormUrl());
+        driver2.navigate().to(oauth.loginForm().build());
 
         // login page should be shown in the second browser
         assertThat(driver2.getPageSource(), Matchers.containsString("kc-login"));
@@ -1064,9 +1064,7 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
     public void verifyEmailExpiredRegistration() throws IOException, MessagingException {
         final String COMMON_ATTR = "verifyEmailRegistrationUser";
 
-        String appInitiatedRegisterUrl = oauth.getLoginFormUrl();
-        appInitiatedRegisterUrl = appInitiatedRegisterUrl.replace("openid-connect/auth", "openid-connect/registrations");
-        driver.navigate().to(appInitiatedRegisterUrl);
+        driver.navigate().to(oauth.registrationForm().build());
 
         registerPage.assertCurrent();
         registerPage.register(COMMON_ATTR, COMMON_ATTR, COMMON_ATTR + "@" + COMMON_ATTR, COMMON_ATTR, COMMON_ATTR, COMMON_ATTR);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ConsentsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ConsentsTest.java
@@ -268,7 +268,7 @@ public class ConsentsTest extends AbstractKeycloakTest {
     public void testConsents() {
         oauth.realm(consumerRealmName());
         oauth.redirectUri(oauth.SERVER_ROOT + "/auth/realms/" + consumerRealmName() + "/app/auth");
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
 
         log.debug("Clicking social " + getIDPAlias());
         accountLoginPage.clickSocial(getIDPAlias());
@@ -416,7 +416,7 @@ public class ConsentsTest extends AbstractKeycloakTest {
         oauth.realm(providerRealmName());
 
         // navigate to account console and login
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().login(getUserLogin(), getUserPassword());
 
         consentPage.assertCurrent();
@@ -426,7 +426,7 @@ public class ConsentsTest extends AbstractKeycloakTest {
         assertTrue(driver.getTitle().contains("AUTH_RESPONSE"));
         assertTrue(driver.getCurrentUrl().contains("error=access_denied"));
 
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().login(getUserLogin(), getUserPassword());
         consentPage.confirm();
 
@@ -484,7 +484,7 @@ public class ConsentsTest extends AbstractKeycloakTest {
         oauth.realm(providerRealmName());
 
         // navigate to account console and login
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().login(getUserLogin(), getUserPassword());
 
         consentPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ImpersonationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ImpersonationTest.java
@@ -233,8 +233,7 @@ public class ImpersonationTest extends AbstractKeycloakTest {
         resp.close();
 
         // Open the URL for the client (will redirect to Keycloak server AuthorizationEndpoint and create authenticationSession)
-        String loginFormUrl = oauth.getLoginFormUrl();
-        driver.navigate().to(loginFormUrl);
+        oauth.openLoginForm();
         loginPage.assertCurrent();
 
         // Impersonate and get SSO cookie. Setup that cookie for webDriver
@@ -243,7 +242,7 @@ public class ImpersonationTest extends AbstractKeycloakTest {
         }
 
         // Open the URL again - should be directly redirected to the app due the SSO login
-        driver.navigate().to(loginFormUrl);
+        oauth.openLoginForm();
         appPage.assertCurrent();
         //KEYCLOAK-12783
         Assert.assertEquals("/auth/realms/master/app/auth", new URL(DroneUtils.getCurrentDriver().getCurrentUrl()).getPath());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/UserTest.java
@@ -485,7 +485,7 @@ public class UserTest extends AbstractAdminTest {
         realm.users().get(userId).update(userRepresentation);
 
         oauth.realm(REALM_NAME);
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
 
         assertEquals("Sign in to your account", PageUtils.getPageTitle(driver));
 
@@ -2899,7 +2899,7 @@ public class UserTest extends AbstractAdminTest {
         assertAdminEvents.assertEvent(realmId, OperationType.ACTION, AdminEventPaths.userResetPasswordPath(userId), ResourceType.USER);
 
         oauth.realm(REALM_NAME);
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
 
         assertEquals("Sign in to your account", PageUtils.getPageTitle(driver));
 
@@ -3285,7 +3285,7 @@ public class UserTest extends AbstractAdminTest {
         getCleanup(REALM_NAME).addUserId(userId);
 
         oauth.realm(REALM_NAME);
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         assertEquals("Test user should be on the login page.", "Sign in to your account", PageUtils.getPageTitle(driver));
         loginPage.login(userName, userPass);
         assertTrue("Test user should be successfully logged in.", driver.getTitle().contains("AUTH_RESPONSE"));
@@ -3298,7 +3298,7 @@ public class UserTest extends AbstractAdminTest {
         assertTrue("Test user should have a password credential set.", passwordCredential.isPresent());
         realm.users().get(userId).removeCredential(passwordCredential.get().getId());
 
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         assertEquals("Test user should be on the login page.", "Sign in to your account", PageUtils.getPageTitle(driver));
         loginPage.login(userName, userPass);
         assertTrue("Test user should fail to log in after password was deleted.",

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/SessionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/client/SessionTest.java
@@ -66,7 +66,7 @@ public class SessionTest extends AbstractClientTest {
         int sessionCount = accountClient.getApplicationSessionCount().get("count");
         assertEquals(0, sessionCount);
 
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().login(testUser);
 
         sessionCount = accountClient.getApplicationSessionCount().get("count");
@@ -83,7 +83,7 @@ public class SessionTest extends AbstractClientTest {
         //List<java.util.Map<String, String>> stats = this.testRealmResource().getClientSessionStats();
         ClientResource account = findClientResourceById("test-app");
 
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().login(testUser);
 
         List<UserSessionRepresentation> sessions = account.getUserSessions(0, 5);
@@ -111,7 +111,7 @@ public class SessionTest extends AbstractClientTest {
         realm.setRememberMe(true);
         adminClient.realm(TEST).update(realm);
 
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().rememberMe(true);
         loginPage.form().login(testUser);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrentLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/concurrency/ConcurrentLoginTest.java
@@ -62,7 +62,6 @@ import org.keycloak.testsuite.util.ClientBuilder;
 import org.keycloak.testsuite.util.HttpClientUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
-import org.keycloak.testsuite.util.oauth.HttpClientManager;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -153,7 +152,7 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
         final HttpClientContext context = HttpClientContext.create();
         CookieStore cookieStore = new BasicCookieStore();
         context.setCookieStore(cookieStore);
-        HttpUriRequest request = handleLogin(getPageContent(oauth.getLoginFormUrl(), httpClient, context), userName, password);
+        HttpUriRequest request = handleLogin(getPageContent(oauth.loginForm().build(), httpClient, context), userName, password);
         assertThat(parseAndCloseResponse(httpClient.execute(request, context)), containsString("<title>AUTH_RESPONSE</title>"));
         return context;
     }
@@ -384,7 +383,7 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
             final HttpClientContext templateContext = clientContexts.get(i % clientContexts.size());
             final HttpClientContext context = HttpClientContext.create();
             context.setCookieStore(templateContext.getCookieStore());
-            String pageContent = getPageContent(oauth1.getLoginFormUrl(), httpClient, context);
+            String pageContent = getPageContent(oauth1.loginForm().build(), httpClient, context);
             assertThat(pageContent, Matchers.containsString("<title>AUTH_RESPONSE</title>"));
             assertThat(context.getRedirectLocations(), Matchers.notNullValue());
             assertThat(context.getRedirectLocations(), Matchers.not(Matchers.empty()));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzEndpointRequestParserTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzEndpointRequestParserTest.java
@@ -8,9 +8,6 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.Matchers;
-import org.keycloak.testsuite.util.RealmBuilder;
-
-import java.util.HashMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -35,7 +32,7 @@ public class AuthzEndpointRequestParserTest extends AbstractTestRealmKeycloakTes
             oauth.addCustomParameter("paramkey5", "paramvalue5");
             oauth.addCustomParameter("paramkey6_too_many", "paramvalue6");
 
-            try (Response response = client.target(oauth.getLoginFormUrl()).request().get()) {
+            try (Response response = client.target(oauth.loginForm().build()).request().get()) {
 
                 assertThat(response.getStatus(), is(equalTo(200)));
                 assertThat(response, Matchers.body(containsString("Sign in")));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcMultipleTabsBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcMultipleTabsBrokerTest.java
@@ -72,7 +72,7 @@ public class KcOidcMultipleTabsBrokerTest  extends AbstractInitializedBaseBroker
             getLogger().infof("URL in tab 1: %s", driver.getCurrentUrl());
 
             // Open new tab 2
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
             Assert.assertTrue(loginPage.isCurrent("consumer"));
             getLogger().infof("URL in tab2: %s", driver.getCurrentUrl());
@@ -112,7 +112,7 @@ public class KcOidcMultipleTabsBrokerTest  extends AbstractInitializedBaseBroker
             loginPage.clickSocial(bc.getIDPAlias());
 
             // Open login page in tab 2
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
             Assert.assertTrue(loginPage.isCurrent("consumer"));
             getLogger().infof("URL in tab2: %s", driver.getCurrentUrl());
@@ -185,7 +185,7 @@ public class KcOidcMultipleTabsBrokerTest  extends AbstractInitializedBaseBroker
             loginPage.clickSocial(bc.getIDPAlias());
 
             // Open login page in tab 2
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
             Assert.assertTrue(loginPage.isCurrent("consumer"));
             getLogger().infof("URL in tab2: %s", driver.getCurrentUrl());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlMultipleTabsBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlMultipleTabsBrokerTest.java
@@ -69,7 +69,7 @@ public class KcSamlMultipleTabsBrokerTest extends AbstractInitializedBaseBrokerT
             loginPage.clickSocial(bc.getIDPAlias());
 
             // Open login page in tab 2
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
             Assert.assertTrue(loginPage.isCurrent("consumer"));
             getLogger().infof("URL in tab2: %s", driver.getCurrentUrl());
@@ -138,7 +138,7 @@ public class KcSamlMultipleTabsBrokerTest extends AbstractInitializedBaseBrokerT
             loginPage.clickSocial(bc.getIDPAlias());
 
             // Open login page in tab 2
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
             Assert.assertTrue(loginPage.isCurrent("consumer"));
             getLogger().infof("URL in tab2: %s", driver.getCurrentUrl());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SocialLoginTest.java
@@ -507,8 +507,8 @@ public class SocialLoginTest extends AbstractKeycloakTest {
 
         driver.navigate().to(
                 currentTestProvider.equals(PAYPAL)
-                        ? oauth.getLoginFormUrl().replace("https://localhost", "https://127.0.0.1")
-                        : oauth.getLoginFormUrl()
+                        ? oauth.loginForm().build().replace("https://localhost", "https://127.0.0.1")
+                        : oauth.loginForm().build()
         );
         loginPage.clickSocial(currentTestProvider.id());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionClusterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cluster/AuthenticationSessionClusterTest.java
@@ -88,7 +88,7 @@ public class AuthenticationSessionClusterTest extends AbstractClusterTest {
         OAuthClient oAuthClient = oauth;
         oAuthClient.baseUrl(UriBuilder.fromUri(backendNode(0).getUriBuilder().build() + "/auth").build("test").toString());
 
-        String testAppLoginNode1URL = oAuthClient.getLoginFormUrl();
+        String testAppLoginNode1URL = oAuthClient.loginForm().build();
 
         Set<String> visitedRoutes = new HashSet<>();
         for (int i = 0; i < 20; i++) {
@@ -112,7 +112,7 @@ public class AuthenticationSessionClusterTest extends AbstractClusterTest {
         OAuthClient oAuthClient = oauth;
         oAuthClient.baseUrl(UriBuilder.fromUri(backendNode(0).getUriBuilder().build() + "/auth").build("test").toString());
 
-        String testAppLoginNode1URL = oAuthClient.getLoginFormUrl();
+        String testAppLoginNode1URL = oAuthClient.loginForm().build();
 
         // Disable route on backend server
         getTestingClientFor(backendNode(0)).server().run(session -> {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
@@ -42,8 +42,6 @@ import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.ContainerAssume;
 import org.keycloak.testsuite.util.HttpClientUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
-import org.keycloak.testsuite.util.oauth.HttpClientManager;
-import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 import org.keycloak.testsuite.util.RealmBuilder;
 import org.openqa.selenium.Cookie;
@@ -119,7 +117,7 @@ public class CookieTest extends AbstractKeycloakTest {
             HttpContext localContext = new BasicHttpContext();
             localContext.setAttribute(HttpClientContext.COOKIE_STORE, cookieStore);
 
-            HttpGet get = new HttpGet(oauth.clientId("test-app").redirectUri(oauth.APP_AUTH_ROOT).getLoginFormUrl());
+            HttpGet get = new HttpGet(oauth.clientId("test-app").redirectUri(oauth.APP_AUTH_ROOT).loginForm().build());
             try (CloseableHttpResponse resp = hc.execute(get, localContext)) {
                 final String pageContent = EntityUtils.toString(resp.getEntity());
 
@@ -157,7 +155,7 @@ public class CookieTest extends AbstractKeycloakTest {
             HttpContext localContext = new BasicHttpContext();
             localContext.setAttribute(HttpClientContext.COOKIE_STORE, cookieStore);
 
-            HttpGet get = new HttpGet(oauth.clientId("test-app").redirectUri(oauth.APP_AUTH_ROOT).getLoginFormUrl());
+            HttpGet get = new HttpGet(oauth.clientId("test-app").redirectUri(oauth.APP_AUTH_ROOT).loginForm().build());
             try (CloseableHttpResponse resp = hc.execute(get, localContext)) {
                 final String pageContent = EntityUtils.toString(resp.getEntity());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/ConcurrentLoginCrossDCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/crossdc/ConcurrentLoginCrossDCTest.java
@@ -77,7 +77,7 @@ public class ConcurrentLoginCrossDCTest extends ConcurrentLoginTest {
             loginTask = new LoginTask(httpClient, userSessionId, LOGIN_TASK_DELAY_MS, LOGIN_TASK_RETRIES, false, Arrays.asList(
               createHttpClientContextForUser(httpClient, "test-user@localhost", "password")
             ));
-            HttpUriRequest request = handleLogin(getPageContent(oauth.getLoginFormUrl(), httpClient, HttpClientContext.create()), "test-user@localhost", "password");
+            HttpUriRequest request = handleLogin(getPageContent(oauth.loginForm().build(), httpClient, HttpClientContext.create()), "test-user@localhost", "password");
             log.debug("Executing login request");
             org.junit.Assert.assertTrue(parseAndCloseResponse(httpClient.execute(request)).contains("<title>AUTH_RESPONSE</title>"));
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosSingleRealmTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosSingleRealmTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractKerberosSingleRealmTest extends AbstractKerberosTe
     public void spnegoNotAvailableTest() throws Exception {
         initHttpClient(false);
 
-        String kcLoginPageLocation = oauth.getLoginFormUrl();
+        String kcLoginPageLocation = oauth.loginForm().build();
 
         Response response = client.target(kcLoginPageLocation).request().get();
         Assert.assertEquals(401, response.getStatus());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/kerberos/AbstractKerberosTest.java
@@ -243,7 +243,7 @@ public abstract class AbstractKerberosTest extends AbstractAuthTest {
 
 
     protected Response spnegoLogin(String username, String password) {
-        String kcLoginPageLocation = oauth.getLoginFormUrl();
+        String kcLoginPageLocation = oauth.loginForm().build();
 
         // Request for SPNEGO login sent with Resteasy client
         spnegoSchemeFactory.setCredentials(username, password);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSamlIdPInitiatedVaryingLetterCaseTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSamlIdPInitiatedVaryingLetterCaseTest.java
@@ -16,14 +16,12 @@
  */
 package org.keycloak.testsuite.federation.ldap;
 
-import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.IdentityProviderResource;
 import org.keycloak.authentication.authenticators.broker.IdpAutoLinkAuthenticatorFactory;
 import org.keycloak.authentication.authenticators.broker.IdpCreateUserIfUniqueAuthenticatorFactory;
 import org.keycloak.broker.saml.SAMLIdentityProviderConfig;
 import org.keycloak.broker.saml.mappers.UsernameTemplateMapper;
 import org.keycloak.broker.saml.mappers.UsernameTemplateMapper.Target;
-import org.keycloak.common.Profile;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.dom.saml.v2.protocol.ResponseType;
 import org.keycloak.models.AuthenticationExecutionModel.Requirement;
@@ -46,7 +44,6 @@ import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapper;
 import org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapperFactory;
 import org.keycloak.testsuite.Assert;
-import org.keycloak.testsuite.ProfileAssume;
 import org.keycloak.testsuite.broker.KcSamlBrokerConfiguration;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.updaters.Creator;
@@ -69,8 +66,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.IDP_SAML_ALIAS;
-import static org.keycloak.testsuite.federation.ldap.AbstractLDAPTest.TEST_REALM_NAME;
-import static org.keycloak.testsuite.federation.ldap.AbstractLDAPTest.ldapModelId;
 
 /**
  *
@@ -279,7 +274,7 @@ public class LDAPSamlIdPInitiatedVaryingLetterCaseTest extends AbstractLDAPTest 
             .build()
 
           // Now navigate to the application where the session should already be created
-          .navigateTo(oauth.getLoginFormUrl())
+          .navigateTo(oauth.loginForm().build())
 
           .assertResponse(Matchers.bodyHC(containsString("AUTH_RESPONSE")))
           .execute();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest.java
@@ -264,13 +264,7 @@ public class AuthenticatorSubflowsTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testSubflow1() throws Exception {
         // Add foo=bar1 . I am redirected to subflow1 - username+password form
-        String loginFormUrl = oauth.getLoginFormUrl();
-        loginFormUrl = loginFormUrl + "&foo=bar1";
-        log.info("loginFormUrl: " + loginFormUrl);
-
-        //Thread.sleep(10000000);
-
-        driver.navigate().to(loginFormUrl);
+        oauth.loginForm().param("foo", "bar1").open();
 
         loginPage.assertCurrent();
 
@@ -285,12 +279,7 @@ public class AuthenticatorSubflowsTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testSubflow2() throws Exception {
         // Don't add 'foo' parameter. I am redirected to subflow2 - push the button
-        String loginFormUrl = oauth.getLoginFormUrl();
-        log.info("loginFormUrl: " + loginFormUrl);
-
-        //Thread.sleep(10000000);
-
-        driver.navigate().to(loginFormUrl);
+        oauth.loginForm().open();
 
         Assert.assertEquals("PushTheButton", driver.getTitle());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest2.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest2.java
@@ -162,11 +162,7 @@ public class AuthenticatorSubflowsTest2 extends AbstractTestRealmKeycloakTest {
     @Test
     public void testSubflow1() throws Exception {
         // Add foo=bar1. I am redirected to subflow1 - username+password form.
-        String loginFormUrl = oauth.getLoginFormUrl();
-        loginFormUrl = loginFormUrl + "&foo=bar1";
-        log.info("loginFormUrl: " + loginFormUrl);
-
-        driver.navigate().to(loginFormUrl);
+        oauth.loginForm().param("foo", "bar1").open();
 
         loginPage.assertCurrent();
 
@@ -181,10 +177,7 @@ public class AuthenticatorSubflowsTest2 extends AbstractTestRealmKeycloakTest {
     @Test
     public void testSubflow2() throws Exception {
         // Don't add 'foo' parameter. I am redirected to subflow1 - username+password form, then move to subflow2.
-        String loginFormUrl = oauth.getLoginFormUrl();
-        log.info("loginFormUrl: " + loginFormUrl);
-
-        driver.navigate().to(loginFormUrl);
+        oauth.openLoginForm();
 
         loginPage.assertCurrent();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserButtonsTest.java
@@ -354,9 +354,7 @@ public class BrowserButtonsTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void appInitiatedRegistrationWithBackButton() throws Exception {
         // Send request from the application directly to 'registrations'
-        String appInitiatedRegisterUrl = oauth.getLoginFormUrl();
-        appInitiatedRegisterUrl = appInitiatedRegisterUrl.replace("openid-connect/auth", "openid-connect/registrations"); // Should be done better way...
-        driver.navigate().to(appInitiatedRegisterUrl);
+        oauth.openRegistrationForm();
         registerPage.assertCurrent();
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/FlowOverrideTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/FlowOverrideTest.java
@@ -204,12 +204,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
     @Test
     public void testWithClientBrowserOverride() throws Exception {
         oauth.clientId(TEST_APP_FLOW);
-        String loginFormUrl = oauth.getLoginFormUrl();
-        log.info("loginFormUrl: " + loginFormUrl);
-
-        //Thread.sleep(10000000);
-
-        driver.navigate().to(loginFormUrl);
+        oauth.openLoginForm();
 
         Assert.assertEquals("PushTheButton", driver.getTitle());
 
@@ -247,12 +242,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
 
     private void testNoOverrideBrowser(String clientId) {
         oauth.clientId(clientId);
-        String loginFormUrl = oauth.getLoginFormUrl();
-        log.info("loginFormUrl: " + loginFormUrl);
-
-        //Thread.sleep(10000000);
-
-        driver.navigate().to(loginFormUrl);
+        oauth.openLoginForm();
 
         loginPage.assertCurrent();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriBuilder;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.After;
 import org.junit.Before;
@@ -395,9 +394,7 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
 
     @Test
     public void acrValuesQueryParameter() {
-        driver.navigate().to(UriBuilder.fromUri(oauth.getLoginFormUrl())
-            .queryParam("acr_values", "gold 3")
-            .build().toString());
+        oauth.loginForm().param("acr_values", "gold 3").open();
         authenticateWithUsernamePassword();
         authenticateWithTotp();
         assertLoggedInWithAcr("gold");
@@ -960,9 +957,7 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
         testClient.update(testClientRep);
 
         // Should request client to authenticate with gold, even if the client sends silver
-        driver.navigate().to(UriBuilder.fromUri(oauth.getLoginFormUrl())
-                .queryParam("acr_values", "silver")
-                .build().toString());
+        oauth.loginForm().param("acr_values", "silver").open();
         authenticateWithUsernamePassword();
         authenticateWithTotp();
         assertLoggedInWithAcr("gold");
@@ -980,9 +975,7 @@ public class LevelOfAssuranceFlowTest extends AbstractTestRealmKeycloakTest {
         testClient.update(testClientRep);
 
         // Should request client to authenticate with gold, even if the client sends silver
-        driver.navigate().to(UriBuilder.fromUri(oauth.getLoginFormUrl())
-                .queryParam("acr_values", "3")
-                .build().toString());
+        oauth.loginForm().param("acr_values", "3").open();
         authenticateWithUsernamePassword();
         authenticateWithTotp();
         authenticateWithButton();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
@@ -33,7 +33,6 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.common.util.UriUtils;
 import org.keycloak.events.Details;
@@ -164,7 +163,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
             updatePasswordPage.assertCurrent();
 
             // Simulate login in different browser tab tab2. I will be on loginPage again.
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
 
             oauth.openLoginForm();
@@ -248,7 +247,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
         getLogger().info("URL in tab1: " + driver.getCurrentUrl());
         // Open new tab 2
-        tabUtil.newTab(oauth.getLoginFormUrl());
+        tabUtil.newTab(oauth.loginForm().build());
         assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
         loginPage.assertCurrent();
         getLogger().info("URL in tab2: " + driver.getCurrentUrl());
@@ -331,7 +330,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
             getLogger().info("URL in tab1: " + driver.getCurrentUrl());
 
             // Open new tab 2
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
             loginPage.assertCurrent();
             getLogger().info("URL in tab2: " + driver.getCurrentUrl());
@@ -370,7 +369,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
             getLogger().info("URL in tab1: " + driver.getCurrentUrl());
 
             // Open new tab 2
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
             loginPage.assertCurrent();
             getLogger().info("URL in tab2: " + driver.getCurrentUrl());
@@ -412,7 +411,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
             AccessToken accessToken = oauth.verifyToken(tokenResponse.getAccessToken());
 
             // seamless login in the second tab, user already authenticated
-            util.newTab(oauth.getLoginFormUrl());
+            util.newTab(oauth.loginForm().build());
             oauth.openLoginForm();
             appPage.assertCurrent();
             events.clear();
@@ -439,7 +438,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
             String originalTab = util.getActualWindowHandle();
 
             // open a new tab performing the passive check
-            String passiveCheckUrl = oauth.responseType("none").prompt("none").getLoginFormUrl();
+            String passiveCheckUrl = oauth.responseType("none").prompt("none").loginForm().build();
             util.newTab(passiveCheckUrl);
             MatcherAssert.assertThat(new URL(oauth.getDriver().getCurrentUrl()).getQuery(), Matchers.containsString("error=login_required"));
 
@@ -682,7 +681,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
             String tab1Url = driver.getCurrentUrl();
 
             // Simulate login in different browser tab tab2. I will be on loginPage again.
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
 
             loginPage.assertCurrent();
@@ -712,7 +711,7 @@ public class MultipleTabsLoginTest extends AbstractTestRealmKeycloakTest {
            driver.manage().deleteCookieNamed("AUTH_SESSION_ID");
 
            // Open new tab 2
-           tabUtil.newTab(oauth.getLoginFormUrl());
+           tabUtil.newTab(oauth.loginForm().build());
            assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
            loginPage.assertCurrent();
            getLogger().info("URL in tab2: " + driver.getCurrentUrl());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ReAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ReAuthenticationTest.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.Page;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
-import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.authenticators.browser.PasswordFormFactory;
 import org.keycloak.authentication.authenticators.browser.UsernameFormFactory;
@@ -376,7 +375,7 @@ public class ReAuthenticationTest extends AbstractTestRealmKeycloakTest {
         oauth.openLoginForm();
         loginPage.assertCurrent();
 
-        tabUtil.newTab(oauth.getLoginFormUrl());
+        tabUtil.newTab(oauth.loginForm().build());
         assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
         oauth.openLoginForm();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -891,7 +891,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
         try {
             // Redirect directly to KC "forgot password" endpoint instead of "authenticate" endpoint
-            String loginUrl = oauth.getLoginFormUrl();
+            String loginUrl = oauth.loginForm().build();
             String forgotPasswordUrl = loginUrl.replace("/auth?", "/forgot-credentials?"); // Workaround, but works
 
             driver.navigate().to(forgotPasswordUrl);
@@ -939,7 +939,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
         try {
             // Redirect directly to KC "forgot password" endpoint instead of "authenticate" endpoint
-            String loginUrl = oauth.getLoginFormUrl();
+            String loginUrl = oauth.loginForm().build();
             String forgotPasswordUrl = loginUrl.replace("/auth?", "/forgot-credentials?"); // Workaround, but works
 
             driver.navigate().to(forgotPasswordUrl);
@@ -988,7 +988,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
 
         try {
             // Redirect directly to KC "forgot password" endpoint instead of "authenticate" endpoint
-            String loginUrl = oauth.getLoginFormUrl();
+            String loginUrl = oauth.loginForm().build();
             String forgotPasswordUrl = loginUrl.replace("/auth?", "/forgot-credentials?"); // Workaround, but works
 
             driver.navigate().to(forgotPasswordUrl);
@@ -1431,7 +1431,7 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void resetPasswordWithLoginHint() throws IOException {
         // Redirect directly to KC "forgot password" endpoint instead of "authenticate" endpoint
-        String loginUrl = oauth.getLoginFormUrl();
+        String loginUrl = oauth.loginForm().build();
         String forgotPasswordUrl = loginUrl.replace("/auth?", "/forgot-credentials?"); // Workaround, but works
 
         driver.navigate().to(forgotPasswordUrl + "&login_hint=test");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/i18n/LoginPageTest.java
@@ -27,7 +27,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.cookie.CookieType;
@@ -383,7 +382,7 @@ public class LoginPageTest extends AbstractI18NTest {
         final String realmLocalizationMessageValue = "We are really sorry...";
 
         saveLocalizationText(locale, realmLocalizationMessageKey, realmLocalizationMessageValue);
-        String nonExistingUrl = oauth.getLoginFormUrl().split("protocol")[0] + "incorrect-path";
+        String nonExistingUrl = oauth.loginForm().build().split("protocol")[0] + "incorrect-path";
         driver.navigate().to(nonExistingUrl);
 
         assertThat(driver.getPageSource(), containsString(realmLocalizationMessageValue));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AuthorizationCodeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AuthorizationCodeTest.java
@@ -46,7 +46,6 @@ import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 import org.keycloak.testsuite.util.WaitUtils;
 import org.openqa.selenium.By;
 
-import jakarta.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -182,8 +181,7 @@ public class AuthorizationCodeTest extends AbstractKeycloakTest {
     @Test
     public void authorizationRequestInvalidResponseType() throws IOException {
         oauth.responseType("tokenn");
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         assertTrue(errorResponse.isRedirected());
@@ -198,7 +196,7 @@ public class AuthorizationCodeTest extends AbstractKeycloakTest {
     public void authorizationRequestInvalidResponseType_testHeaders() throws IOException {
         oauth.responseType("tokenn");
         Client client = AdminClientUtil.createResteasyClient();
-        Response response = client.target(oauth.getLoginFormUrl()).request().get();
+        Response response = client.target(oauth.loginForm().build()).request().get();
 
         assertThat(response.getStatus(), is(equalTo(302)));
         String cacheControl = response.getHeaderString(HttpHeaders.CACHE_CONTROL);
@@ -212,8 +210,7 @@ public class AuthorizationCodeTest extends AbstractKeycloakTest {
         oauth.responseMode(OIDCResponseMode.FORM_POST.value());
         oauth.responseType("tokenn");
         oauth.stateParamHardcoded("OpenIdConnect.AuthenticationProperties=2302984sdlk");
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         String error = driver.findElement(By.id("error")).getText();
         String state = driver.findElement(By.id("state")).getText();
@@ -228,8 +225,7 @@ public class AuthorizationCodeTest extends AbstractKeycloakTest {
         oauth.responseMode(OIDCResponseMode.FORM_POST.value());
         oauth.responseType(null);
         oauth.stateParamHardcoded("OpenIdConnect.AuthenticationProperties=2302984sdlk");
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         String error = driver.findElement(By.id("error")).getText();
         String errorDescription = driver.findElement(By.id("error_description")).getText();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutTest.java
@@ -836,7 +836,7 @@ public class BackchannelLogoutTest extends AbstractNestedBrokerTest {
         linkAccountButton.click();
 
         WaitUtils.waitForPageToLoad();
-        oauth.fillLoginForm(nbc.getUserLogin(), USER_PASSWORD_CONSUMER_REALM, false);
+        oauth.fillLoginForm(nbc.getUserLogin(), USER_PASSWORD_CONSUMER_REALM);
     }
 
     private String getClientId(String realm, String clientId) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.common.util.Retry;
@@ -49,7 +48,6 @@ import java.util.Map;
 
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response.Status;
-import jakarta.ws.rs.core.UriBuilder;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -355,10 +353,9 @@ public class LogoutTest extends AbstractKeycloakTest {
 
         setTimeOffset(1);
 
-        String loginFormUri = UriBuilder.fromUri(oauth.getLoginFormUrl())
-                .queryParam(OIDCLoginProtocol.PROMPT_PARAM, OIDCLoginProtocol.PROMPT_VALUE_LOGIN)
-                .build().toString();
-        driver.navigate().to(loginFormUri);
+        oauth.loginForm()
+                .prompt(OIDCLoginProtocol.PROMPT_VALUE_LOGIN)
+                .open();
 
         loginPage.assertCurrent();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2OnlyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2OnlyTest.java
@@ -94,7 +94,7 @@ public class OAuth2OnlyTest extends AbstractTestRealmKeycloakTest {
     // If scope=openid is missing, IDToken won't be present
     @Test
     public void testMissingIDToken() {
-        String loginFormUrl = oauth.getLoginFormUrl();
+        String loginFormUrl = oauth.loginForm().build();
         loginFormUrl = ActionURIUtils.removeQueryParamFromURI(loginFormUrl, OAuth2Constants.SCOPE);
 
         driver.navigate().to(loginFormUrl);
@@ -143,7 +143,7 @@ public class OAuth2OnlyTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testMissingRedirectUri() throws Exception {
         // OAuth2 login without redirect_uri. It will be allowed.
-        String loginFormUrl = oauth.getLoginFormUrl();
+        String loginFormUrl = oauth.loginForm().build();
         loginFormUrl = ActionURIUtils.removeQueryParamFromURI(loginFormUrl, OAuth2Constants.SCOPE);
         loginFormUrl = ActionURIUtils.removeQueryParamFromURI(loginFormUrl, OAuth2Constants.REDIRECT_URI);
 
@@ -154,7 +154,7 @@ public class OAuth2OnlyTest extends AbstractTestRealmKeycloakTest {
 
         // Client 'more-uris-client' has 2 redirect uris. OAuth2 login without redirect_uri won't be allowed
         oauth.client("more-uris-client");
-        loginFormUrl = oauth.getLoginFormUrl();
+        loginFormUrl = oauth.loginForm().build();
         loginFormUrl = ActionURIUtils.removeQueryParamFromURI(loginFormUrl, OAuth2Constants.SCOPE);
         loginFormUrl = ActionURIUtils.removeQueryParamFromURI(loginFormUrl, OAuth2Constants.REDIRECT_URI);
 
@@ -178,7 +178,7 @@ public class OAuth2OnlyTest extends AbstractTestRealmKeycloakTest {
     public void testMissingNonceInOAuth2ImplicitFlow() throws Exception {
         oauth.responseType("token");
         oauth.nonce(null);
-        String loginFormUrl = oauth.getLoginFormUrl();
+        String loginFormUrl = oauth.loginForm().build();
         loginFormUrl = ActionURIUtils.removeQueryParamFromURI(loginFormUrl, OAuth2Constants.SCOPE);
 
         driver.navigate().to(loginFormUrl);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthProofKeyForCodeExchangeTest.java
@@ -225,9 +225,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     public void accessTokenRequestInPKCEWithoutCodeChallengeWithValidCodeChallengeMethod() throws Exception {
     	// test case : failure : A-1-7
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_PLAIN);
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
     	
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
 
@@ -243,9 +241,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	// test case : failure : A-1-8
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
     	oauth.codeChallenge("ABCDEFGabcdefg1234567ABCDEFGabcdefg1234567"); // 42
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
     	
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
 
@@ -262,9 +258,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_PLAIN);
     	oauth.codeChallenge("3fRc92kac_keic8c7al-3ncbdoaie.DDeizlck3~3fRc92kac_keic8c7al-3ncbdoaie.DDeizlck3~3fRc92kac_keic8c7al-3ncbdoaie.DDeizlck3~123456789"); // 129
 
-    	UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
     	
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
 
@@ -366,9 +360,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
     	oauth.codeChallenge(codeChallenge);
     	oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
     	
-    	UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        
-        driver.navigate().to(b.build().toURL());
+    	oauth.openLoginForm();
     	
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
 
@@ -612,9 +604,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
             oauth.codeChallenge(codeChallenge);
             oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_PLAIN);
 
-            UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-
-            driver.navigate().to(b.build().toURL());
+            oauth.openLoginForm();
 
             AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
 
@@ -636,9 +626,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
             String codeChallenge = generateS256CodeChallenge(codeVerifier);
             oauth.codeChallenge(codeChallenge);
 
-            UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-
-            driver.navigate().to(b.build().toURL());
+            oauth.openLoginForm();
 
             AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
 
@@ -659,9 +647,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
             setPkceActivationSettings("test-app", OAuth2Constants.PKCE_METHOD_S256);
             oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
 
-            UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-
-            driver.navigate().to(b.build().toURL());
+            oauth.openLoginForm();
 
             AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
 
@@ -683,9 +669,7 @@ public class OAuthProofKeyForCodeExchangeTest extends AbstractKeycloakTest {
             oauth.codeChallenge("invalid");
             oauth.codeChallengeMethod(OAuth2Constants.PKCE_METHOD_S256);
 
-            UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-
-            driver.navigate().to(b.build().toURL());
+            oauth.openLoginForm();
 
             AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
@@ -256,7 +256,7 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
             MatcherAssert.assertThat(false, is(isSessionActive(tokenResponse.getSessionState())));
 
             // check if the back channel logout succeeded
-            driver.navigate().to(oauth.getLoginFormUrl());
+            oauth.openLoginForm();
             WaitUtils.waitForPageToLoad();
             loginPage.assertCurrent();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RefreshTokenTest.java
@@ -694,7 +694,7 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
             assertNotEquals(refreshToken1.getOtherClaims().get(Constants.REUSE_ID), refreshToken1.getId());
 
             //login with tab 2
-            tabUtil.newTab(oauth.getLoginFormUrl());
+            tabUtil.newTab(oauth.loginForm().build());
             assertThat(tabUtil.getCountOfTabs(), Matchers.equalTo(2));
 
             loginEvent = events.expectLogin().assertEvent();
@@ -1242,7 +1242,9 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
                     r.setSsoSessionIdleTimeoutRememberMe(500);
                     r.setSsoSessionIdleTimeout(100);
                 }).update()) {
-            oauth.doRememberMeLogin("test-user@localhost", "password");
+            oauth.openLoginForm();
+            loginPage.setRememberMe(true);
+            loginPage.login("test-user@localhost", "password");
 
             EventRepresentation loginEvent = events.expectLogin().assertEvent();
 
@@ -1642,7 +1644,9 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
                     r.setSsoSessionMaxLifespan(50);
                 }).update()) {
 
-            oauth.doRememberMeLogin("test-user@localhost", "password");
+            oauth.openLoginForm();
+            loginPage.setRememberMe(true);
+            loginPage.login("test-user@localhost", "password");
 
             EventRepresentation loginEvent = events.expectLogin().assertEvent();
 
@@ -2170,9 +2174,9 @@ public class RefreshTokenTest extends AbstractKeycloakTest {
         processExpectedValidRefresh(sessionId, refreshTokenParsed1, refreshToken);
 
         // Open the tab with prompt=login. AuthenticationSession will be created with same ID like userSession
-        String loginFormUri = UriBuilder.fromUri(oauth.getLoginFormUrl())
-                .queryParam(OIDCLoginProtocol.PROMPT_PARAM, OIDCLoginProtocol.PROMPT_VALUE_LOGIN)
-                .build().toString();
+        String loginFormUri = oauth.loginForm()
+                .param(OIDCLoginProtocol.PROMPT_PARAM, OIDCLoginProtocol.PROMPT_VALUE_LOGIN)
+                .build();
         driver.navigate().to(loginFormUri);
 
         loginPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
 
-import jakarta.ws.rs.core.HttpHeaders;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -61,9 +60,6 @@ import org.keycloak.testsuite.util.TokenSignatureUtil;
 import org.keycloak.util.BasicAuthHelper;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
-
-import jakarta.ws.rs.core.UriBuilder;
-import org.keycloak.utils.MediaType;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -582,9 +578,9 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
 
         setTimeOffset(1);
 
-        String loginFormUri = UriBuilder.fromUri(oauth.getLoginFormUrl())
-                .queryParam(OIDCLoginProtocol.PROMPT_PARAM, OIDCLoginProtocol.PROMPT_VALUE_LOGIN)
-                .build().toString();
+        String loginFormUri = oauth.loginForm()
+                .param(OIDCLoginProtocol.PROMPT_PARAM, OIDCLoginProtocol.PROMPT_VALUE_LOGIN)
+                .build();
         driver.navigate().to(loginFormUri);
 
         loginPage.assertCurrent();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
@@ -819,8 +819,7 @@ public class ParTest extends AbstractClientPoliciesTest {
         oauth.requestUri(IMAGINARY_REQUEST_URI);
         String state = oauth.stateParamRandom().getState();
         oauth.stateParamHardcoded(state);
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         Assert.assertFalse(errorResponse.isRedirected());
     }
@@ -867,8 +866,7 @@ public class ParTest extends AbstractClientPoliciesTest {
         // use same redirect_uri
         state = oauth.stateParamRandom().getState();
         oauth.stateParamHardcoded(state);
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         Assert.assertFalse(errorResponse.isRedirected());
     }
@@ -915,8 +913,7 @@ public class ParTest extends AbstractClientPoliciesTest {
         oauth.requestUri(requestUri);
         String state = oauth.stateParamRandom().getState();
         oauth.stateParamHardcoded(state);
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         Assert.assertFalse(errorResponse.isRedirected());
     }
@@ -980,8 +977,7 @@ public class ParTest extends AbstractClientPoliciesTest {
         oauth.requestUri(requestUri);
         String state = oauth.stateParamRandom().getState();
         oauth.stateParamHardcoded(state);
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         Assert.assertFalse(errorResponse.isRedirected());
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AuthorizationTokenResponseModeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AuthorizationTokenResponseModeTest.java
@@ -208,8 +208,7 @@ public class AuthorizationTokenResponseModeTest extends AbstractTestRealmKeycloa
         oauth.responseType("code id_token");
         oauth.stateParamHardcoded("OpenIdConnect.AuthenticationProperties=2302984sdlk");
         oauth.nonce("123456");
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         AuthorizationResponseToken responseToken = oauth.verifyAuthorizationResponseToken(errorResponse.getResponse());
@@ -226,8 +225,7 @@ public class AuthorizationTokenResponseModeTest extends AbstractTestRealmKeycloa
         oauth.responseType("code id_token");
         oauth.stateParamHardcoded("OpenIdConnect.AuthenticationProperties=2302984sdlk");
         oauth.nonce("123456");
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         AuthorizationResponseToken responseToken = oauth.verifyAuthorizationResponseToken(errorResponse.getResponse());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCBackwardsCompatibilityTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCBackwardsCompatibilityTest.java
@@ -102,7 +102,7 @@ public class OIDCBackwardsCompatibilityTest extends AbstractTestRealmKeycloakTes
         client.update(clientRep);
 
         // Open login again and assert session_state not present
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         org.keycloak.testsuite.Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
         events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();
 
@@ -130,7 +130,7 @@ public class OIDCBackwardsCompatibilityTest extends AbstractTestRealmKeycloakTes
         client.update(clientRep);
 
         // Open login again and assert iss parameter is not present
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         org.keycloak.testsuite.Assert.assertEquals(AppPage.RequestType.AUTH_RESPONSE, appPage.getRequestType());
         events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();
 
@@ -146,8 +146,7 @@ public class OIDCBackwardsCompatibilityTest extends AbstractTestRealmKeycloakTes
     public void testExcludeIssuerParameterOnError() throws IOException {
         // Open login form and login fails. Assert iss parameter is present
         oauth.responseType("tokenn");
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         assertTrue(errorResponse.isRedirected());
@@ -164,7 +163,7 @@ public class OIDCBackwardsCompatibilityTest extends AbstractTestRealmKeycloakTes
         client.update(clientRep);
 
         // Open login again and assert iss parameter is not present
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         errorResponse = oauth.parseLoginResponse();
         assertTrue(errorResponse.isRedirected());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -1037,10 +1037,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
 
         setTimeOffset(1);
 
-        String loginFormUri = UriBuilder.fromUri(oauth.getLoginFormUrl())
-                .queryParam(OIDCLoginProtocol.PROMPT_PARAM, OIDCLoginProtocol.PROMPT_VALUE_LOGIN)
-                .build().toString();
-        driver.navigate().to(loginFormUri);
+        oauth.loginForm().prompt(OIDCLoginProtocol.PROMPT_VALUE_LOGIN).open();
 
         loginPage.assertCurrent();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/flows/AbstractOIDCResponseTypeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/flows/AbstractOIDCResponseTypeTest.java
@@ -113,8 +113,7 @@ public abstract class AbstractOIDCResponseTypeTest extends AbstractTestRealmKeyc
     @Test
     public void authorizationRequestMissingResponseType() throws IOException {
         oauth.responseType(null);
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         // Always read error from the "query"
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
@@ -130,7 +129,7 @@ public abstract class AbstractOIDCResponseTypeTest extends AbstractTestRealmKeyc
 
     protected void validateNonceNotUsedErrorExpected() {
         oauth.nonce(null);
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
 
         assertFalse(loginPage.isCurrent());
         assertTrue(appPage.isCurrent());
@@ -148,8 +147,7 @@ public abstract class AbstractOIDCResponseTypeTest extends AbstractTestRealmKeyc
         // Disable implicit flow for client
         clientManagerBuilder().implicitFlow(false);
 
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         Assert.assertTrue(errorResponse.isRedirected());
@@ -167,8 +165,7 @@ public abstract class AbstractOIDCResponseTypeTest extends AbstractTestRealmKeyc
         // Disable standard flow for client
         clientManagerBuilder().standardFlow(false);
 
-        UriBuilder b = UriBuilder.fromUri(oauth.getLoginFormUrl());
-        driver.navigate().to(b.build().toURL());
+        oauth.openLoginForm();
 
         AuthorizationEndpointResponse errorResponse = oauth.parseLoginResponse();
         Assert.assertTrue(errorResponse.isRedirected());
@@ -188,7 +185,7 @@ public abstract class AbstractOIDCResponseTypeTest extends AbstractTestRealmKeyc
             oauth.nonce(nonce);
         }
 
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
 
         loginPage.assertCurrent();
         loginPage.login("test-user@localhost", "password");
@@ -206,7 +203,7 @@ public abstract class AbstractOIDCResponseTypeTest extends AbstractTestRealmKeyc
             oauth.redirectUri(redirectUri);
         }
 
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
 
         loginPage.assertCurrent();
         loginPage.login("test-user@localhost", "password");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
@@ -24,7 +24,6 @@ import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.hamcrest.Matcher;
@@ -35,7 +34,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.organization.authentication.authenticators.browser.OrganizationAuthenticatorFactory;
-import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
@@ -205,7 +203,7 @@ public class OrganizationAuthenticationTest extends AbstractOrganizationTest {
         oauth.clientId("broker-app");
         String expectedUsername = URLEncoder.encode(member.getEmail(), StandardCharsets.UTF_8);
         oauth.realm(bc.consumerRealmName());
-        driver.navigate().to(oauth.getLoginFormUrl() + "&" + OIDCLoginProtocol.LOGIN_HINT_PARAM + "=" + expectedUsername);
+        oauth.loginForm().loginHint(expectedUsername).open();
         assertThat(loginPage.getUsername(), Matchers.equalTo(URLDecoder.decode(expectedUsername, StandardCharsets.UTF_8)));
 
         // continue authenticating without setting the username

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/ssl/TrustStoreEmailTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/ssl/TrustStoreEmailTest.java
@@ -102,7 +102,7 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
             SslMailServer.startWithSsl(privateKey);
         }
 
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(user.getUsername(), "password");
 
         EventRepresentation sendEvent = events.expectRequiredAction(EventType.SEND_VERIFY_EMAIL)
@@ -143,7 +143,7 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
 
         assertCurrentUrlStartsWith(OAuthClient.APP_AUTH_ROOT);
         AccountHelper.logout(testRealm(), user.getUsername());
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         testRealmLoginPage.form().login(user.getUsername(), "password");
         assertCurrentUrlStartsWith(OAuthClient.APP_AUTH_ROOT);
     }
@@ -158,7 +158,7 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
         UserRepresentation user = ApiUtil.findUserByUsername(testRealm(), "test-user@localhost");
 
         SslMailServer.startWithSsl(this.getClass().getClassLoader().getResource(SslMailServer.INVALID_KEY).getFile());
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().login(user.getUsername(), "password");
 
         events.expectRequiredAction(EventType.SEND_VERIFY_EMAIL_ERROR)
@@ -186,7 +186,7 @@ public class TrustStoreEmailTest extends AbstractTestRealmKeycloakTest {
                 .setSmtpServer("host", "localhost.localdomain")
                 .update()) {
             SslMailServer.startWithSsl(this.getClass().getClassLoader().getResource(SslMailServer.PRIVATE_KEY).getFile());
-            driver.navigate().to(oauth.getLoginFormUrl());
+            oauth.openLoginForm();
             loginPage.form().login(user.getUsername(), "password");
 
             events.expectRequiredAction(EventType.SEND_VERIFY_EMAIL_ERROR)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UIRealmResourceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/user/profile/UIRealmResourceTest.java
@@ -223,7 +223,7 @@ public class UIRealmResourceTest extends AbstractTestRealmKeycloakTest {
         updateRealmExt(toUIRealmRepresentation(testRealm, upConfig));
 
         // open the registration form
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().register();
         registerPage.assertCurrent();
 
@@ -253,7 +253,7 @@ public class UIRealmResourceTest extends AbstractTestRealmKeycloakTest {
         updateRealmExt(toUIRealmRepresentation(testRealm, upConfig));
 
         // open the registration form
-        driver.navigate().to(oauth.getLoginFormUrl());
+        oauth.openLoginForm();
         loginPage.form().register();
         registerPage.assertCurrent();
 


### PR DESCRIPTION
## Summary
- Added support for using a builder pattern to add custom parameters to login URLs
- Enhanced OAuth client with flexible login URL construction capabilities
- Refactored test suite to use new login builder pattern for better maintainability

## Changes
- Created LoginUrlBuilder class with fluent API for URL construction
- Modified AbstractOAuthClient to support custom parameter builders
- Updated AbstractUrlBuilder with enhanced parameter handling
- Refactored 50+ test files to use new builder pattern
- Removed deprecated OAuth client parameter methods

## Test plan
- [ ] Test login URL construction with custom parameters
- [ ] Verify OAuth client builder functionality across different flows
- [ ] Test parameter injection in authorization code flow
- [ ] Confirm PKCE parameter handling with new builder
- [ ] Test login URL generation with custom authentication flows
- [ ] Verify backward compatibility with existing OAuth flows

🤖 Generated with [Claude Code](https://claude.ai/code)