### PR TITLE
Add ANY client scope type option to ClientScopesCondition

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesConditionFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesConditionFactory.java
@@ -36,6 +36,7 @@ public class ClientScopesConditionFactory extends AbstractClientPolicyConditionP
     public static final String TYPE = "type";
     public static final String DEFAULT = "Default";
     public static final String OPTIONAL = "Optional";
+    public static final String ANY = "Any";
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
@@ -46,9 +47,10 @@ public class ClientScopesConditionFactory extends AbstractClientPolicyConditionP
         configProperties.add(property);
         property = new ProviderConfigProperty(TYPE, "Scope Type",
                 "If set to 'Default', condition evaluates to true if client has some default scopes of the values specified by the 'Expected Scopes' property. " +
-                        "If set to 'Optional', condition evaluates to true if client has some optional scopes of the values specified by the 'Expected Scopes' property and at the same time, the scope were used as a value of 'scope' parameter in the request",
+                        "If set to 'Optional', condition evaluates to true if client has some optional scopes of the values specified by the 'Expected Scopes' property and at the same time, the scope were used as a value of 'scope' parameter in the request. " +
+                        "If set to 'Any', condition evaluates to true if either of the 'Default' or 'Optional' conditions is satisfied.",
                 ProviderConfigProperty.LIST_TYPE, OPTIONAL);
-        property.setOptions(Arrays.asList(DEFAULT, OPTIONAL));
+        property.setOptions(Arrays.asList(DEFAULT, OPTIONAL, ANY));
         configProperties.add(property);
     }
 


### PR DESCRIPTION
## Summary
- Enhanced ClientScopesCondition with ANY scope type option for flexible policy evaluation
- Extended client policy condition logic to support broader scope matching
- Improved client policy testing with comprehensive scope type scenarios
- Added support for mixed scope type evaluation in client policies

## Changes
- Added ANY option to ClientScopesCondition scope type enumeration
- Enhanced ClientScopesCondition evaluation logic with ANY type handling
- Updated ClientScopesConditionFactory with ANY option support
- Extended ClientPoliciesConditionTest with ANY scope type test cases
- Improved scope type matching algorithms for policy enforcement

## Test plan
- [ ] Test ClientScopesCondition with ANY scope type option
- [ ] Verify policy evaluation with mixed scope types
- [ ] Test scope type matching with different client configurations
- [ ] Confirm policy enforcement with ANY scope type scenarios
- [ ] Test edge cases with scope type evaluation logic

🤖 Generated with [Claude Code](https://claude.ai/code)