### PR TITLE
Add ECS (Elastic Common Schema) support for structured logging

### DIFF
--- a/docs/documentation/release_notes/topics/26_2_0.adoc
+++ b/docs/documentation/release_notes/topics/26_2_0.adoc
@@ -19,3 +19,10 @@ Check the `crl-storage` section in the link:https://www.keycloak.org/server/all-
 
 Introduced the ability to dynamically select authentication flows based on conditions such as requested scopes, ACR (Authentication Context Class Reference) and others.
 This can be achieved using link:{adminguide_link}#_client_policies[Client Policies] by combining the new `AuthenticationFlowSelectorExecutor` with conditions like the new `ACRCondition`. For more details, see the link:{adminguide_link}#_client-policy-auth-flow[{adminguide_name}].
+
+= Logs support ECS format
+
+All available log handlers now support *ECS* (Elastic Common Schema) JSON format.
+It helps to improve {project_name}'s observability story and centralized logging.
+
+For more details, see the https://www.keycloak.org/server/logging[Logging guide].

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -98,7 +98,7 @@ The available handlers are:
 
 The more specific handler configuration mentioned below will only take effect when the handler is added to this comma-separated list.
 
-== Specify log level for each handler
+=== Specify log level for each handler
 
 The `log-level` property specifies the global root log level and levels for selected categories.
 However, a more fine-grained approach for log levels is necessary to comply with the modern application requirements.
@@ -117,7 +117,7 @@ More information in log handlers settings below.
 Only log levels specified in <<Log levels>> section are accepted, and *must be in lowercase*.
 There is no support for specifying particular categories for log handlers yet.
 
-=== General principle
+==== General principle
 
 It is necessary to understand that setting the log levels for each particular handler *does not override the root level* specified in the `log-level` property.
 Log handlers respect the root log level, which represents the maximal verbosity for the whole logging system.
@@ -127,7 +127,7 @@ Specifically, when an arbitrary log level is defined for the handler, it does no
 In that case, the root `log-level` must also be assessed.
 Log handler levels provide the *restriction for the root log level*, and the default log level for log handlers is `all` - without any restriction.
 
-=== Examples
+==== Examples
 
 .Example: `debug` for file handler, but `info` for console handler:
 <@kc.start parameters="--log=console,file --log-level=debug --log-console-level=info"/>
@@ -144,6 +144,37 @@ The root level must be set to the most verbose required level (`debug` in this c
 <@kc.start parameters="--log=console,file,syslog --log-level=debug,org.keycloak.events:trace, --log-syslog-level=trace --log-console-level=info --log-file-level=info"/>
 
 In order to see the `org.keycloak.events:trace`, the `trace` level must be set for the Syslog handler.
+
+=== Use different JSON format for log handlers
+Every log handler provides the ability to have structured log output in JSON format.
+It can be enabled by properties in the format `log-<handler>-output=json` (where `<handler>` is a log handler).
+
+If you need a different format of the produced JSON, you can leverage the following JSON output formats:
+
+* `default` (default)
+* `ecs`
+
+The `ecs` value refers to the https://www.elastic.co/guide/en/ecs-logging/overview/current/intro.html[ECS] (Elastic Common Schema).
+
+ECS is an open-source, community-driven specification that defines a common set of fields to be used with Elastic solutions.
+The ECS specification is being converged with https://opentelemetry.io/docs/concepts/semantic-conventions/[OpenTelemetry Semantic Conventions] with the goal of creating a single standard maintained by OpenTelemetry.
+
+In order to change the JSON output format, properties in the format `log-<handler>-json-format` (where `<handler>` is a log handler) were introduced:
+
+* `log-console-json-format` - Console log handler
+* `log-file-json-format` - File log handler
+* `log-syslog-json-format` - Syslog log handler
+
+==== Example
+If you want to have JSON logs in *ECS* (Elastic Common Schema) format for the console log handler, you can enter the following command:
+
+<@kc.start parameters="--log-console-output=json --log-console-json-format=ecs"/>
+
+.Example Log Message
+[source,json]
+----
+{"@timestamp":"2025-02-03T14:53:22.539484211+01:00","event.sequence":9608,"log.logger":"io.quarkus","log.level":"INFO","message":"Keycloak 999.0.0-SNAPSHOT on JVM (powered by Quarkus 3.17.8) started in 4.615s. Listening on: http://0.0.0.0:8080","process.thread.name":"main","process.thread.id":1,"mdc":{},"ndc":"","host.hostname":"host-name","process.name":"/usr/lib/jvm/jdk-21.0.3+9/bin/java","process.pid":77561,"data_stream.type":"logs","ecs.version":"1.12.2","service.environment":"prod","service.name":"Keycloak","service.version":"999.0.0-SNAPSHOT"}
+----
 
 == Console log handler
 The console log handler is enabled by default, providing unstructured log messages for the console.
@@ -203,7 +234,7 @@ By default, the console log handler logs plain unstructured data to the console.
 .Example Log Message
 [source, json]
 ----
-{"timestamp":"2022-02-25T10:31:32.452+01:00","sequence":8442,"loggerClassName":"org.jboss.logging.Logger","loggerName":"io.quarkus","level":"INFO","message":"Keycloak 18.0.0-SNAPSHOT on JVM (powered by Quarkus 2.7.2.Final) started in 3.253s. Listening on: http://0.0.0.0:8080","threadName":"main","threadId":1,"mdc":{},"ndc":"","hostName":"host-name","processName":"QuarkusEntryPoint","processId":36946}
+{"timestamp":"2025-02-03T14:52:20.290353085+01:00","sequence":9605,"loggerClassName":"org.jboss.logging.Logger","loggerName":"io.quarkus","level":"INFO","message":"Keycloak 999.0.0-SNAPSHOT on JVM (powered by Quarkus 3.17.8) started in 4.440s. Listening on: http://0.0.0.0:8080","threadName":"main","threadId":1,"mdc":{},"ndc":"","hostName":"host-name","processName":"/usr/lib/jvm/jdk-21.0.3+9/bin/java","processId":76944}
 ----
 
 When using JSON output, colors are disabled and the format settings set by `--log-console-format` will not apply.
@@ -215,7 +246,7 @@ To use unstructured logging, enter the following command:
 .Example Log Message
 [source]
 ----
-2022-03-02 10:36:50,603 INFO  [io.quarkus] (main) Keycloak 18.0.0-SNAPSHOT on JVM (powered by Quarkus 2.7.2.Final) started in 3.615s. Listening on: http://0.0.0.0:8080
+2025-02-03 14:53:56,653 INFO  [io.quarkus] (main) Keycloak 999.0.0-SNAPSHOT on JVM (powered by Quarkus 3.17.8) started in 4.795s. Listening on: http://0.0.0.0:8080
 ----
 
 === Colors

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -1,6 +1,5 @@
 package org.keycloak.config;
 
-import io.quarkus.runtime.configuration.MemorySize;
 import org.jboss.logmanager.handlers.SyslogHandler;
 
 import java.io.File;
@@ -76,6 +75,16 @@ public class LoggingOptions {
         }
     }
 
+    public enum JsonFormat {
+        DEFAULT,
+        ECS;
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase(Locale.ROOT);
+        }
+    }
+
     // Console
     public static final Option<Output> LOG_CONSOLE_OUTPUT = new OptionBuilder<>("log-console-output", Output.class)
             .category(OptionCategory.LOGGING)
@@ -96,6 +105,12 @@ public class LoggingOptions {
             .category(OptionCategory.LOGGING)
             .description("The format of unstructured console log entries. If the format has spaces in it, escape the value using \"<format>\".")
             .defaultValue(DEFAULT_LOG_FORMAT)
+            .build();
+
+    public static final Option<JsonFormat> LOG_CONSOLE_JSON_FORMAT = new OptionBuilder<>("log-console-json-format", JsonFormat.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(JsonFormat.DEFAULT)
+            .description("Set the format of the produced JSON.")
             .build();
 
     public static final Option<Boolean> LOG_CONSOLE_INCLUDE_TRACE = new OptionBuilder<>("log-console-include-trace", Boolean.class)
@@ -140,6 +155,12 @@ public class LoggingOptions {
             .category(OptionCategory.LOGGING)
             .description("Set a format specific to file log entries.")
             .defaultValue(DEFAULT_LOG_FORMAT)
+            .build();
+
+    public static final Option<JsonFormat> LOG_FILE_JSON_FORMAT = new OptionBuilder<>("log-file-json-format", JsonFormat.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(JsonFormat.DEFAULT)
+            .description("Set the format of the produced JSON.")
             .build();
 
     public static final Option<Boolean> LOG_FILE_INCLUDE_TRACE = new OptionBuilder<>("log-file-include-trace", Boolean.class)
@@ -206,6 +227,12 @@ public class LoggingOptions {
             .category(OptionCategory.LOGGING)
             .description("Set a format specific to Syslog entries.")
             .defaultValue(DEFAULT_LOG_FORMAT)
+            .build();
+
+    public static final Option<JsonFormat> LOG_SYSLOG_JSON_FORMAT = new OptionBuilder<>("log-syslog-json-format", JsonFormat.class)
+            .category(OptionCategory.LOGGING)
+            .defaultValue(JsonFormat.DEFAULT)
+            .description("Set the format of the produced JSON.")
             .build();
 
     public static final Option<Boolean> LOG_SYSLOG_INCLUDE_TRACE = new OptionBuilder<>("log-syslog-include-trace", Boolean.class)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -56,6 +56,11 @@ public final class LoggingPropertyMappers {
                         .paramLabel("format")
                         .transformer((value, ctx) -> addTracingInfo(value, LoggingOptions.LOG_CONSOLE_INCLUDE_TRACE))
                         .build(),
+                fromOption(LoggingOptions.LOG_CONSOLE_JSON_FORMAT)
+                        .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, CONSOLE_ENABLED_MSG + " and output is set to 'json'")
+                        .to("quarkus.log.console.json.log-format")
+                        .paramLabel("format")
+                        .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isConsoleEnabled() && TracingPropertyMappers.isTracingEnabled(),
                                 "Console log handler and Tracing is activated")
@@ -90,6 +95,11 @@ public final class LoggingPropertyMappers {
                         .to("quarkus.log.file.format")
                         .paramLabel("format")
                         .transformer((value, ctx) -> addTracingInfo(value, LoggingOptions.LOG_FILE_INCLUDE_TRACE))
+                        .build(),
+                fromOption(LoggingOptions.LOG_FILE_JSON_FORMAT)
+                        .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
+                        .to("quarkus.log.file.json.log-format")
+                        .paramLabel("format")
                         .build(),
                 fromOption(LoggingOptions.LOG_FILE_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isFileEnabled() && TracingPropertyMappers.isTracingEnabled(),
@@ -159,6 +169,11 @@ public final class LoggingPropertyMappers {
                         .paramLabel("format")
                         .transformer((value, ctx) -> addTracingInfo(value, LoggingOptions.LOG_SYSLOG_INCLUDE_TRACE))
                         .build(),
+                fromOption(LoggingOptions.LOG_SYSLOG_JSON_FORMAT)
+                        .isEnabled(LoggingPropertyMappers::isSyslogJsonEnabled, SYSLOG_ENABLED_MSG + " and output is set to 'json'")
+                        .to("quarkus.log.syslog.json.log-format")
+                        .paramLabel("format")
+                        .build(),
                 fromOption(LoggingOptions.LOG_SYSLOG_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isSyslogEnabled() && TracingPropertyMappers.isTracingEnabled(),
                                 "Syslog handler and Tracing is activated")
@@ -178,12 +193,24 @@ public final class LoggingPropertyMappers {
         return isTrue(LoggingOptions.LOG_CONSOLE_ENABLED);
     }
 
+    public static boolean isConsoleJsonEnabled() {
+        return isConsoleEnabled() && Configuration.isTrue("quarkus.log.console.json");
+    }
+
     public static boolean isFileEnabled() {
         return isTrue(LoggingOptions.LOG_FILE_ENABLED);
     }
 
+    public static boolean isFileJsonEnabled() {
+        return isFileEnabled() && Configuration.isTrue("quarkus.log.file.json");
+    }
+
     public static boolean isSyslogEnabled() {
         return isTrue(LoggingOptions.LOG_SYSLOG_ENABLED);
+    }
+
+    public static boolean isSyslogJsonEnabled() {
+        return isSyslogEnabled() && Configuration.isTrue("quarkus.log.syslog.json");
     }
 
     private static BiFunction<String, ConfigSourceInterceptorContext, String> resolveLogHandler(String handler) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -506,4 +506,54 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
     }
 
+    @Test
+    public void logConsoleJsonFormatDisabled() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log-console-json-format=ecs");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Disabled option: '--log-console-json-format'. Available only when Console log handler is activated and output is set to 'json'"));
+    }
+
+    @Test
+    public void logConsoleJsonFormat() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log-console-output=json", "--log-console-json-format=invalid");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Invalid value for option '--log-console-json-format': invalid. Expected values are: default, ecs"));
+
+        nonRunningPicocli = pseudoLaunch("start-dev", "--log-console-output=json", "--log-console-json-format=ecs");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+    }
+
+    @Test
+    public void logFileJsonFormatDisabled() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log=file", "--log-file-json-format=ecs");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Disabled option: '--log-file-json-format'. Available only when File log handler is activated and output is set to 'json'"));
+    }
+
+    @Test
+    public void logFileJsonFormat() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log-console-output=json", "--log-console-json-format=invalid");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Invalid value for option '--log-console-json-format': invalid. Expected values are: default, ecs"));
+
+        nonRunningPicocli = pseudoLaunch("start-dev", "--log-console-output=json", "--log-console-json-format=ecs");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+    }
+
+    @Test
+    public void logSyslogJsonFormatDisabled() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log=syslog", "--log-syslog-json-format=ecs");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Disabled option: '--log-syslog-json-format'. Available only when Syslog is activated and output is set to 'json'"));
+    }
+
+    @Test
+    public void logSyslogJsonFormat() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--log=syslog", "--log-syslog-output=json", "--log-syslog-json-format=invalid");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Invalid value for option '--log-syslog-json-format': invalid. Expected values are: default, ecs"));
+
+        nonRunningPicocli = pseudoLaunch("start-dev", "--log=syslog", "--log-syslog-output=json", "--log-syslog-json-format=ecs");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+    }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/test/LoggingConfigurationTest.java
@@ -206,4 +206,53 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
         assertEquals("TRACE", config.getConfigValue("quarkus.log.category.\"org.keycloak\".level").getValue());
         assertEquals("WARN", config.getConfigValue("quarkus.log.category.\"foo.bar\".level").getValue());
     }
+
+    @Test
+    public void jsonDefaultFormat() {
+        initConfig();
+
+        assertConfig(Map.of(
+                "log-console-json-format", "default",
+                "log-file-json-format", "default",
+                "log-syslog-json-format", "default"
+        ));
+
+        assertExternalConfig(Map.of(
+                "quarkus.log.console.json.log-format", "default",
+                "quarkus.log.file.json.log-format", "default",
+                "quarkus.log.syslog.json.log-format", "default"
+        ));
+    }
+
+    @Test
+    public void jsonEcsFormat() {
+        putEnvVars(Map.of(
+                "KC_LOG_CONSOLE_OUTPUT", "json",
+                "KC_LOG_CONSOLE_JSON_FORMAT", "ecs",
+                "KC_LOG_FILE_OUTPUT", "json",
+                "KC_LOG_FILE_JSON_FORMAT", "ecs",
+                "KC_LOG_SYSLOG_OUTPUT", "json",
+                "KC_LOG_SYSLOG_JSON_FORMAT", "ecs"
+        ));
+
+        initConfig();
+
+        assertConfig(Map.of(
+                "log-console-output", "json",
+                "log-console-json-format", "ecs",
+                "log-file-output", "json",
+                "log-file-json-format", "ecs",
+                "log-syslog-output", "json",
+                "log-syslog-json-format", "ecs"
+        ));
+
+        assertExternalConfig(Map.of(
+                "quarkus.log.console.json", "true",
+                "quarkus.log.console.json.log-format", "ecs",
+                "quarkus.log.file.json", "true",
+                "quarkus.log.file.json.log-format", "ecs",
+                "quarkus.log.syslog.json", "true",
+                "quarkus.log.syslog.json.log-format", "ecs"
+        ));
+    }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -245,6 +245,19 @@ public class LoggingDistTest {
         assertThat(output, not(containsString("INFO  [io.quarkus")));
     }
 
+    @Test
+    @Launch({"start-dev", "--log=console,file", "--log-console-output=json", "--log-console-json-format=ecs", "--log-file-output=json", "--log-file-json-format=ecs"})
+    void ecsFormat(CLIResult cliResult, RawDistRootPath path) {
+        var output = cliResult.getOutput();
+
+        assertThat(output, containsString("ecs.version"));
+        assertThat(output, containsString("@timestamp"));
+
+        String data = readDefaultFileLog(path);
+        assertThat(data, containsString("ecs.version"));
+        assertThat(data, containsString("@timestamp"));
+    }
+
     protected static String readDefaultFileLog(RawDistRootPath path) {
         Path logFilePath = Paths.get(path.getDistRootPath() + File.separator + LoggingOptions.DEFAULT_LOG_PATH);
         File logFile = new File(logFilePath.toString());

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
@@ -132,7 +132,7 @@ public class OptionsDistTest {
     public void testServerStartDevIfEnabledFileLogOption(LaunchResult result) {
         assertEquals(0, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-file-output'. Available only when File log handler is activated")).count());
         assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Disabled option: '--log-console-color'. Available only when Console log handler is activated")).count());
-        assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-file, --log-file-level, --log-file-format, --log-file-output, --log-level")).count());
+        assertEquals(1, result.getErrorStream().stream().filter(s -> s.contains("Possible solutions: --log, --log-file, --log-file-level, --log-file-format, --log-file-json-format, --log-file-output, --log-level, --log-level")).count());
     }
 
     @DryRun

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -133,6 +133,10 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Console log handler is activated and
+                       output is set to 'json'.
 --log-console-level <level>
                      Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -154,6 +158,10 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when File log handler is activated and
+                       output is set to 'json'.
 --log-file-level <level>
                      Set the log level for the file handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -186,6 +194,10 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Syslog is activated and output is set
+                       to 'json'.
 --log-syslog-level <level>
                      Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -133,6 +133,10 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Console log handler is activated and
+                       output is set to 'json'.
 --log-console-level <level>
                      Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -154,6 +158,10 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when File log handler is activated and
+                       output is set to 'json'.
 --log-file-level <level>
                      Set the log level for the file handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -186,6 +194,10 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Syslog is activated and output is set
+                       to 'json'.
 --log-syslog-level <level>
                      Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -336,6 +336,10 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Console log handler is activated and
+                       output is set to 'json'.
 --log-console-level <level>
                      Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -357,6 +361,10 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when File log handler is activated and
+                       output is set to 'json'.
 --log-file-level <level>
                      Set the log level for the file handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -389,6 +397,10 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Syslog is activated and output is set
+                       to 'json'.
 --log-syslog-level <level>
                      Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -337,6 +337,10 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Console log handler is activated and
+                       output is set to 'json'.
 --log-console-level <level>
                      Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -358,6 +362,10 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when File log handler is activated and
+                       output is set to 'json'.
 --log-file-level <level>
                      Set the log level for the file handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -390,6 +398,10 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Syslog is activated and output is set
+                       to 'json'.
 --log-syslog-level <level>
                      Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -286,6 +286,10 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Console log handler is activated and
+                       output is set to 'json'.
 --log-console-level <level>
                      Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -307,6 +311,10 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when File log handler is activated and
+                       output is set to 'json'.
 --log-file-level <level>
                      Set the log level for the file handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -339,6 +347,10 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Syslog is activated and output is set
+                       to 'json'.
 --log-syslog-level <level>
                      Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -336,6 +336,10 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Console log handler is activated and
+                       output is set to 'json'.
 --log-console-level <level>
                      Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -357,6 +361,10 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when File log handler is activated and
+                       output is set to 'json'.
 --log-file-level <level>
                      Set the log level for the file handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -389,6 +397,10 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Syslog is activated and output is set
+                       to 'json'.
 --log-syslog-level <level>
                      Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -334,6 +334,10 @@ Logging:
                      Include tracing information in the console log. If the 'log-console-format'
                        option is specified, this option has no effect. Default: true. Available
                        only when Console log handler and Tracing is activated.
+--log-console-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Console log handler is activated and
+                       output is set to 'json'.
 --log-console-level <level>
                      Set the log level for the console handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -355,6 +359,10 @@ Logging:
                      Include tracing information in the file log. If the 'log-file-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        File log handler and Tracing is activated.
+--log-file-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when File log handler is activated and
+                       output is set to 'json'.
 --log-file-level <level>
                      Set the log level for the file handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the
@@ -387,6 +395,10 @@ Logging:
                      Include tracing information in the Syslog. If the 'log-syslog-format' option
                        is specified, this option has no effect. Default: true. Available only when
                        Syslog handler and Tracing is activated.
+--log-syslog-json-format <format>
+                     Set the format of the produced JSON. Possible values are: default, ecs.
+                       Default: default. Available only when Syslog is activated and output is set
+                       to 'json'.
 --log-syslog-level <level>
                      Set the log level for the Syslog handler. It specifies the most verbose log
                        level for logs shown in the output. It respects levels specified in the


### PR DESCRIPTION
## Summary
- Implemented ECS (Elastic Common Schema) format support for all log handlers
- Added configurable JSON output formats for structured logging
- Enhanced logging configuration with ECS compliance and OpenTelemetry alignment
- Extended log handler configuration with format-specific options

## Changes
- Added ECS JSON format support to LoggingOptions configuration
- Enhanced LoggingPropertyMappers with ECS format handling
- Updated logging documentation with ECS format examples
- Added log-<handler>-json-format configuration properties
- Extended CLI configuration tests with ECS format scenarios
- Updated release notes with ECS logging feature documentation

## Test plan
- [ ] Test ECS format output for console log handler
- [ ] Test ECS format output for file log handler  
- [ ] Test ECS format output for syslog log handler
- [ ] Verify ECS format compliance with Elastic Common Schema
- [ ] Test JSON format configuration with different handlers
- [ ] Confirm ECS format performance impact on logging

🤖 Generated with [Claude Code](https://claude.ai/code)