### PR TITLE
Fixing Re-authentication with passkeys

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
@@ -55,7 +55,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
     public static final String SESSION_INVALID = "SESSION_INVALID";
 
     // Flag is true if user was already set in the authContext before this authenticator was triggered. In this case we skip clearing of the user after unsuccessful password authentication
-    protected static final String USER_SET_BEFORE_USERNAME_PASSWORD_AUTH = "USER_SET_BEFORE_USERNAME_PASSWORD_AUTH";
+    public static final String USER_SET_BEFORE_USERNAME_PASSWORD_AUTH = "USER_SET_BEFORE_USERNAME_PASSWORD_AUTH";
 
     @Override
     public void action(AuthenticationFlowContext context) {
@@ -219,11 +219,7 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
         context.getEvent().user(user);
         context.getEvent().error(Errors.INVALID_USER_CREDENTIALS);
 
-        if (isUserAlreadySetBeforeUsernamePasswordAuth(context)) {
-            LoginFormsProvider form = context.form();
-            form.setAttribute(LoginFormsProvider.USERNAME_HIDDEN, true);
-            form.setAttribute(LoginFormsProvider.REGISTRATION_DISABLED, true);
-        }
+        AuthenticatorUtils.setupReauthenticationInUsernamePasswordFormError(context);
 
         Response challengeResponse = challenge(context, getDefaultChallengeMessage(context), FIELD_PASSWORD);
         if(isEmptyPassword) {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernameForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernameForm.java
@@ -44,7 +44,7 @@ public final class UsernameForm extends UsernamePasswordForm {
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
-        if (context.getUser() != null) {
+        if (context.getUser() != null && !isConditionalPasskeysEnabled()) {
             // We can skip the form when user is re-authenticating. Unless current user has some IDP set, so he can re-authenticate with that IDP
             if (!this.hasLinkedBrokers(context)) {
                 context.success();

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -110,10 +110,10 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
                     formData.add("rememberMe", "on");
                 }
             }
-            // setup webauthn data when the user is not already selected
-            if (webauthnAuth != null && webauthnAuth.isPasskeysEnabled()) {
-                webauthnAuth.fillContextForm(context);
-            }
+        }
+        // setup webauthn data when passkeys enabled
+        if (isConditionalPasskeysEnabled()) {
+            webauthnAuth.fillContextForm(context);
         }
         Response challengeResponse = challenge(context, formData);
         context.challenge(challengeResponse);
@@ -134,8 +134,8 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
 
     @Override
     protected Response challenge(AuthenticationFlowContext context, String error, String field) {
-        if (context.getUser() == null && webauthnAuth != null && webauthnAuth.isPasskeysEnabled()) {
-            // setup webauthn data when the user is not already selected
+        if (isConditionalPasskeysEnabled()) {
+            // setup webauthn data when possible
             webauthnAuth.fillContextForm(context);
         }
         return super.challenge(context, error, field);
@@ -155,6 +155,10 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
     @Override
     public void close() {
 
+    }
+
+    protected boolean isConditionalPasskeysEnabled() {
+        return webauthnAuth != null && webauthnAuth.isPasskeysEnabled();
     }
 
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
@@ -97,7 +97,8 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
 
         UserModel user = context.getUser();
         boolean isUserIdentified = false;
-        if (user != null) {
+
+        if (shouldShowWebAuthnAuthenticators(context)) {
             // in 2 Factor Scenario where the user has already been identified
             WebAuthnAuthenticatorsBean authenticators = new WebAuthnAuthenticatorsBean(context.getSession(), context.getRealm(), user, getCredentialType());
             if (authenticators.getAuthenticators().isEmpty()) {
@@ -118,6 +119,14 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
         form.setAttribute(WebAuthnConstants.SHOULD_DISPLAY_AUTHENTICATORS, shouldDisplayAuthenticators(context));
 
         return form;
+    }
+
+    /**
+     * @param context authentication context
+     * @return true if the available webauthn authenticators should be shown on the screen. Typically during 2-factor authentication for example
+     */
+    protected boolean shouldShowWebAuthnAuthenticators(AuthenticationFlowContext context) {
+        return context.getUser() != null;
     }
 
     protected WebAuthnPolicy getWebAuthnPolicy(AuthenticationFlowContext context) {

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnConditionalUIAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnConditionalUIAuthenticator.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.function.Function;
 import org.keycloak.WebAuthnConstants;
 import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
 import org.keycloak.common.Profile;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.KeycloakSession;
@@ -48,6 +49,9 @@ public class WebAuthnConditionalUIAuthenticator extends WebAuthnPasswordlessAuth
         // the passkey failed, show error and maintain passkeys
         context.form().setError(errorCase, "");
         context.form().setAttribute(WebAuthnConstants.ENABLE_WEBAUTHN_CONDITIONAL_UI, Boolean.TRUE);
+
+        AuthenticatorUtils.setupReauthenticationInUsernamePasswordFormError(context);
+
         fillContextForm(context);
         return errorChallenge.apply(context);
     }
@@ -55,5 +59,10 @@ public class WebAuthnConditionalUIAuthenticator extends WebAuthnPasswordlessAuth
     public boolean isPasskeysEnabled() {
         return Profile.isFeatureEnabled(Profile.Feature.PASSKEYS) &&
                 Boolean.TRUE.equals(session.getContext().getRealm().getWebAuthnPolicyPasswordless().isPasskeysEnabled());
+    }
+
+    // Do not show authenticators during login with conditional passkeys (For example during username/password)
+    protected boolean shouldShowWebAuthnAuthenticators(AuthenticationFlowContext context) {
+        return false;
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/util/AuthenticatorUtils.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/util/AuthenticatorUtils.java
@@ -23,6 +23,7 @@ import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.common.util.Time;
 import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.events.Errors;
+import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.*;
 import org.keycloak.services.managers.BruteForceProtector;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -30,6 +31,8 @@ import org.keycloak.util.JsonSerialization;
 
 import java.io.IOException;
 import java.util.Map;
+
+import static org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator.USER_SET_BEFORE_USERNAME_PASSWORD_AUTH;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
@@ -116,4 +119,17 @@ public final class AuthenticatorUtils {
             throw new IllegalStateException(e);
         }
     }
+
+
+    // Make sure that form is setup for "re-authentication" rather than regular authentication if some error happens during re-authentication
+    public static void setupReauthenticationInUsernamePasswordFormError(AuthenticationFlowContext context) {
+        String userAlreadySetBeforeUsernamePasswordAuth = context.getAuthenticationSession().getAuthNote(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH);
+
+        if (Boolean.parseBoolean(userAlreadySetBeforeUsernamePasswordAuth)) {
+            LoginFormsProvider form = context.form();
+            form.setAttribute(LoginFormsProvider.USERNAME_HIDDEN, true);
+            form.setAttribute(LoginFormsProvider.REGISTRATION_DISABLED, true);
+        }
+    }
+
 }


### PR DESCRIPTION
This PR fixes re-authentication issues with passkeys, addressing problems where users were unable to properly re-authenticate using WebAuthn during authentication flows.

## Changes

- Enhanced `AbstractUsernameFormAuthenticator` to properly handle re-authentication scenarios
- Added `setupReauthenticationInUsernamePasswordFormError` method in `AuthenticatorUtils` 
- Modified `UsernameForm` to support conditional passkey flows during re-authentication
- Updated `WebAuthnConditionalUIAuthenticator` with improved error handling
- Enhanced `WebAuthnAuthenticator` with better authentication flow control
- Added comprehensive test coverage for passkey re-authentication scenarios

## Key Improvements

- Username remains hidden during re-authentication
- Registration is properly disabled in re-auth flows  
- WebAuthn forms remain accessible throughout the process
- Passkey authentication works correctly during re-authentication

## Testing

- Added new test cases in `PasskeysUsernamePasswordFormTest`
- Enhanced existing tests in `PasskeysUsernameFormTest` 
- Updated organization authentication tests in `PasskeysOrganizationAuthenticationTest`

This change ensures that passkey re-authentication works seamlessly while maintaining security and user experience standards.

Closes #41242
Closes #41008