### PR TITLE
Fixing Re-authentication with passkeys

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -112,7 +112,7 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
             }
         }
         // setup webauthn data when passkeys enabled
-        if (isConditionalPasskeysEnabled()) {
+        if (isConditionalPasskeysEnabled(context.getUser())) {
             webauthnAuth.fillContextForm(context);
         }
         Response challengeResponse = challenge(context, formData);
@@ -134,7 +134,7 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
 
     @Override
     protected Response challenge(AuthenticationFlowContext context, String error, String field) {
-        if (isConditionalPasskeysEnabled()) {
+        if (isConditionalPasskeysEnabled(context.getUser())) {
             // setup webauthn data when possible
             webauthnAuth.fillContextForm(context);
         }
@@ -157,8 +157,8 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
 
     }
 
-    protected boolean isConditionalPasskeysEnabled() {
-        return webauthnAuth != null && webauthnAuth.isPasskeysEnabled();
+    protected boolean isConditionalPasskeysEnabled(UserModel user) {
+        return webauthnAuth != null && webauthnAuth.isPasskeysEnabled() && user != null;
     }
 
 }


### PR DESCRIPTION
This PR fixes re-authentication issues with passkeys, addressing problems where users were unable to properly re-authenticate using WebAuthn during authentication flows.

## Changes

- Enhanced `AbstractUsernameFormAuthenticator` to properly handle re-authentication scenarios
- Added `setupReauthenticationInUsernamePasswordFormError` method in `AuthenticatorUtils` 
- Modified `UsernameForm` to support conditional passkey flows during re-authentication
- Updated `WebAuthnConditionalUIAuthenticator` with improved error handling
- Enhanced `WebAuthnAuthenticator` with better authentication flow control
- Updated method signatures for better user context validation
- Added comprehensive test coverage for passkey re-authentication scenarios

## Key Improvements

- Username remains hidden during re-authentication
- Registration is properly disabled in re-auth flows  
- WebAuthn forms remain accessible throughout the process
- Passkey authentication works correctly during re-authentication
- Enhanced user context validation in conditional passkey checks

## Testing

- Added new test cases in `PasskeysUsernamePasswordFormTest`
- Enhanced existing tests in `PasskeysUsernameFormTest` 
- Updated organization authentication tests in `PasskeysOrganizationAuthenticationTest`

This change ensures that passkey re-authentication works seamlessly while maintaining security and user experience standards.

Closes #41242
Closes #41008